### PR TITLE
Fix event sort order

### DIFF
--- a/code/backend/Cleanuparr.Api/Controllers/EventsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/EventsController.cs
@@ -87,10 +87,6 @@ public class EventsController : ControllerBase
             .Take(pageSize)
             .ToListAsync();
 
-        events = events
-            .OrderBy(e => e.Timestamp)
-            .ToList();
-
         // Return paginated result
         var result = new PaginatedResult<AppEvent>
         {


### PR DESCRIPTION
In my opinion, the current behaviour is confusing. Each page of events is sorted in ascending order by the timestamp, but the pages are in descending order by timestamp. This feels off to me, so I'm putting forward this PR to keep events in descending order, which feels more natural.