### PR TITLE
feat: Add RDT-Client download client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Cleanuparr was created primarily to address malicious files, such as `*.lnk` or 
 - **Transmission**
 - **Deluge**
 - **µTorrent**
+- **RDT-Client**
 
 ### Platforms
 - **Docker**

--- a/code/backend/Cleanuparr.Domain/Enums/DownloadClientTypeName.cs
+++ b/code/backend/Cleanuparr.Domain/Enums/DownloadClientTypeName.cs
@@ -6,4 +6,5 @@ public enum DownloadClientTypeName
     Deluge,
     Transmission,
     uTorrent,
+    RdtClient,
 }

--- a/code/backend/Cleanuparr.Infrastructure/Extensions/RdtExtensions.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Extensions/RdtExtensions.cs
@@ -1,0 +1,35 @@
+using Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+using Cleanuparr.Infrastructure.Services;
+
+namespace Cleanuparr.Infrastructure.Extensions;
+
+public static class RdtExtensions
+{
+    public static bool ShouldIgnore(this RdtService.RdtTorrentInfo download, IReadOnlyList<string> ignoredDownloads)
+    {
+        foreach (string value in ignoredDownloads)
+        {
+            if (download.Hash?.Equals(value, StringComparison.InvariantCultureIgnoreCase) ?? false)
+            {
+                return true;
+            }
+
+            if (download.Category?.Equals(value, StringComparison.InvariantCultureIgnoreCase) ?? false)
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(download.Tags))
+            {
+                var tags = download.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (tags.Any(tag => tag.Equals(value, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/DownloadServiceFactory.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/DownloadServiceFactory.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using DelugeService = Cleanuparr.Infrastructure.Features.DownloadClient.Deluge.DelugeService;
 using QBitService = Cleanuparr.Infrastructure.Features.DownloadClient.QBittorrent.QBitService;
+using RdtService = Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient.RdtService;
 using TransmissionService = Cleanuparr.Infrastructure.Features.DownloadClient.Transmission.TransmissionService;
 using UTorrentService = Cleanuparr.Infrastructure.Features.DownloadClient.UTorrent.UTorrentService;
 
@@ -52,6 +53,7 @@ public sealed class DownloadServiceFactory
             DownloadClientTypeName.Deluge => CreateDelugeService(downloadClientConfig),
             DownloadClientTypeName.Transmission => CreateTransmissionService(downloadClientConfig),
             DownloadClientTypeName.uTorrent => CreateUTorrentService(downloadClientConfig),
+            DownloadClientTypeName.RdtClient => CreateRdtService(downloadClientConfig),
             _ => throw new NotSupportedException($"Download client type {downloadClientConfig.TypeName} is not supported")
         };
     }
@@ -136,6 +138,27 @@ public sealed class DownloadServiceFactory
         UTorrentService service = new(
             logger, cache, filenameEvaluator, striker, dryRunInterceptor,
             hardLinkFileService, httpClientProvider, eventPublisher, blocklistProvider, downloadClientConfig, loggerFactory
+        );
+        
+        return service;
+    }
+
+    private RdtService CreateRdtService(DownloadClientConfig downloadClientConfig)
+    {
+        var logger = _serviceProvider.GetRequiredService<ILogger<RdtService>>();
+        var cache = _serviceProvider.GetRequiredService<IMemoryCache>();
+        var filenameEvaluator = _serviceProvider.GetRequiredService<IFilenameEvaluator>();
+        var striker = _serviceProvider.GetRequiredService<IStriker>();
+        var dryRunInterceptor = _serviceProvider.GetRequiredService<IDryRunInterceptor>();
+        var hardLinkFileService = _serviceProvider.GetRequiredService<IHardLinkFileService>();
+        var httpClientProvider = _serviceProvider.GetRequiredService<IDynamicHttpClientProvider>();
+        var eventPublisher = _serviceProvider.GetRequiredService<EventPublisher>();
+        var blocklistProvider = _serviceProvider.GetRequiredService<BlocklistProvider>();
+        
+        // Create the RdtService instance
+        RdtService service = new(
+            logger, cache, filenameEvaluator, striker, dryRunInterceptor,
+            hardLinkFileService, httpClientProvider, eventPublisher, blocklistProvider, downloadClientConfig
         );
         
         return service;

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/IRdtService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/IRdtService.cs
@@ -1,0 +1,5 @@
+namespace Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+
+public interface IRdtService : IDownloadService, IDisposable
+{
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtService.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Cleanuparr.Infrastructure.Events;
+using Cleanuparr.Infrastructure.Features.Files;
+using Cleanuparr.Infrastructure.Features.ItemStriker;
+using Cleanuparr.Infrastructure.Features.MalwareBlocker;
+using Cleanuparr.Infrastructure.Http;
+using Cleanuparr.Infrastructure.Interceptors;
+using Cleanuparr.Persistence.Models.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+
+public partial class RdtService : DownloadService, IRdtService
+{
+    private readonly string _apiBaseUrl;
+
+    public RdtService(
+        ILogger<RdtService> logger,
+        IMemoryCache cache,
+        IFilenameEvaluator filenameEvaluator,
+        IStriker striker,
+        IDryRunInterceptor dryRunInterceptor,
+        IHardLinkFileService hardLinkFileService,
+        IDynamicHttpClientProvider httpClientProvider,
+        EventPublisher eventPublisher,
+        BlocklistProvider blocklistProvider,
+        DownloadClientConfig downloadClientConfig
+    ) : base(
+        logger, cache, filenameEvaluator, striker, dryRunInterceptor, hardLinkFileService,
+        httpClientProvider, eventPublisher, blocklistProvider, downloadClientConfig
+    )
+    {
+        // RDT-Client implements qBittorrent API at /api/v2
+        _apiBaseUrl = downloadClientConfig.Host!.ToString().TrimEnd('/') + "/api/v2";
+    }
+    
+    public override async Task LoginAsync()
+    {
+        // RDT-Client supports two auth modes: user/password and no auth
+        if (string.IsNullOrEmpty(_downloadClientConfig.Username) && string.IsNullOrEmpty(_downloadClientConfig.Password))
+        {
+            _logger.LogDebug("No credentials configured for RDT-Client {clientId}, skipping login", _downloadClientConfig.Id);
+            return;
+        }
+
+        try
+        {
+            // Make direct HTTP POST request to /api/v2/auth/login with form-encoded data
+            var loginUrl = $"{_apiBaseUrl}/auth/login";
+
+            var formData = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("username", _downloadClientConfig.Username ?? ""),
+                new KeyValuePair<string, string>("password", _downloadClientConfig.Password ?? "")
+            });
+
+            var response = await _httpClient.PostAsync(loginUrl, formData);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Login failed with status {response.StatusCode}: {responseContent}");
+            }
+
+            if (responseContent.Contains("Fails"))
+            {
+                throw new UnauthorizedAccessException("Login failed: Invalid credentials");
+            }
+
+            _logger.LogDebug("Successfully logged in to RDT-Client {clientId}", _downloadClientConfig.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to login to RDT-Client {clientId}", _downloadClientConfig.Id);
+            throw;
+        }
+    }
+
+    public override async Task<HealthCheckResult> HealthCheckAsync()
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        try
+        {
+            bool hasCredentials = !string.IsNullOrEmpty(_downloadClientConfig.Username) ||
+                                  !string.IsNullOrEmpty(_downloadClientConfig.Password);
+
+            if (hasCredentials)
+            {
+                // Test by logging in
+                await LoginAsync();
+            }
+            else
+            {
+                // Test connectivity using version endpoint
+                var versionUrl = $"{_apiBaseUrl}/app/version";
+                var response = await _httpClient.GetAsync(versionUrl);
+                response.EnsureSuccessStatusCode();
+            }
+
+            stopwatch.Stop();
+
+            return new HealthCheckResult
+            {
+                IsHealthy = true,
+                ResponseTime = stopwatch.Elapsed
+            };
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+
+            _logger.LogWarning(ex, "Health check failed for RDT-Client {clientId}", _downloadClientConfig.Id);
+
+            return new HealthCheckResult
+            {
+                IsHealthy = false,
+                ErrorMessage = $"Connection failed: {ex.Message}",
+                ResponseTime = stopwatch.Elapsed
+            };
+        }
+    }
+
+
+    protected async Task<List<RdtTorrentInfo>> GetTorrentListAsync(string? filter = null, string? category = null)
+    {
+        var url = $"{_apiBaseUrl}/torrents/info";
+        var queryParams = new List<string>();
+
+        if (!string.IsNullOrEmpty(filter))
+            queryParams.Add($"filter={filter}");
+        if (!string.IsNullOrEmpty(category))
+            queryParams.Add($"category={Uri.EscapeDataString(category)}");
+
+        if (queryParams.Count > 0)
+            url += "?" + string.Join("&", queryParams);
+
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<List<RdtTorrentInfo>>() ?? new List<RdtTorrentInfo>();
+    }
+
+    protected async Task<List<RdtTorrentContent>> GetTorrentContentsAsync(string hash)
+    {
+        var url = $"{_apiBaseUrl}/torrents/files?hash={hash}";
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<List<RdtTorrentContent>>() ?? new List<RdtTorrentContent>();
+    }
+
+    protected async Task<Dictionary<string, RdtCategory>> GetCategoriesAsync()
+    {
+        var url = $"{_apiBaseUrl}/torrents/categories";
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<Dictionary<string, RdtCategory>>() ?? new Dictionary<string, RdtCategory>();
+    }
+
+    protected async Task AddCategoryAsync(string name)
+    {
+        var url = $"{_apiBaseUrl}/torrents/createCategory";
+        var formData = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("category", name)
+        });
+
+        var response = await _httpClient.PostAsync(url, formData);
+        response.EnsureSuccessStatusCode();
+    }
+
+    protected async Task SetTorrentCategoryAsync(string[] hashes, string category)
+    {
+        var url = $"{_apiBaseUrl}/torrents/setCategory";
+        var formData = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("hashes", string.Join("|", hashes)),
+            new KeyValuePair<string, string>("category", category)
+        });
+
+        var response = await _httpClient.PostAsync(url, formData);
+        response.EnsureSuccessStatusCode();
+    }
+
+
+    protected async Task DeleteAsync(string[] hashes, bool deleteFiles)
+    {
+        var url = $"{_apiBaseUrl}/torrents/delete";
+        var formData = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("hashes", string.Join("|", hashes)),
+            new KeyValuePair<string, string>("deleteFiles", deleteFiles.ToString().ToLower())
+        });
+
+        var response = await _httpClient.PostAsync(url, formData);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public override void Dispose()
+    {
+        // No resources to dispose
+    }
+
+    // DTOs matching RDT-Client API responses
+    public class RdtTorrentInfo
+    {
+        public string? Hash { get; set; }
+        public string? Name { get; set; }
+        public string? Category { get; set; }
+        public string? Tags { get; set; }
+        public double Ratio { get; set; }
+        public TimeSpan? SeedingTime { get; set; }
+        public string? SavePath { get; set; }
+    }
+
+    public class RdtTorrentContent
+    {
+        public int? Index { get; set; }
+        public string? Name { get; set; }
+        public int Priority { get; set; }
+    }
+
+    public class RdtCategory
+    {
+        public string? Name { get; set; }
+        public string? SavePath { get; set; }
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceCB.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceCB.cs
@@ -1,0 +1,36 @@
+using Cleanuparr.Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+
+public partial class RdtService
+{
+    /// <inheritdoc/>
+    public override async Task<BlockFilesResult> BlockUnwantedFilesAsync(string hash, IReadOnlyList<string> ignoredDownloads)
+    {
+        BlockFilesResult result = new();
+
+        try
+        {
+            var torrents = await GetTorrentListAsync();
+            RdtTorrentInfo? download = torrents.FirstOrDefault(x => x.Hash == hash);
+
+            if (download is null)
+            {
+                _logger.LogDebug("failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+                return result;
+            }
+
+            result.Found = true;
+
+            _logger.LogDebug("File blocking for RDT-Client is limited - torrent {name}", download.Name);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error blocking files for torrent {hash} in RDT-Client", hash);
+            return result;
+        }
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceDC.cs
@@ -1,0 +1,265 @@
+using Cleanuparr.Domain.Enums;
+using Cleanuparr.Infrastructure.Extensions;
+using Cleanuparr.Infrastructure.Features.Context;
+using Cleanuparr.Persistence.Models.Configuration.DownloadCleaner;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+
+public partial class RdtService
+{
+    /// <inheritdoc/>
+    public override async Task<List<object>?> GetSeedingDownloads()
+    {
+        var torrentList = await GetTorrentListAsync(filter: "completed");
+        return torrentList?.Where(x => !string.IsNullOrEmpty(x.Hash))
+            .Cast<object>()
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public override List<object>? FilterDownloadsToBeCleanedAsync(List<object>? downloads, List<CleanCategory> categories) =>
+        downloads
+            ?.Cast<RdtTorrentInfo>()
+            .Where(x => !string.IsNullOrEmpty(x.Hash))
+            .Where(x => categories.Any(cat => cat.Name.Equals(x.Category, StringComparison.InvariantCultureIgnoreCase)))
+            .Cast<object>()
+            .ToList();
+
+    /// <inheritdoc/>
+    public override List<object>? FilterDownloadsToChangeCategoryAsync(List<object>? downloads, List<string> categories)
+    {
+        var downloadCleanerConfig = ContextProvider.Get<DownloadCleanerConfig>(nameof(DownloadCleanerConfig));
+
+        return downloads
+            ?.Cast<RdtTorrentInfo>()
+            .Where(x => !string.IsNullOrEmpty(x.Hash))
+            .Where(x => categories.Any(cat => cat.Equals(x.Category, StringComparison.InvariantCultureIgnoreCase)))
+            .Where(x =>
+            {
+                if (downloadCleanerConfig.UnlinkedUseTag)
+                {
+                    if (!string.IsNullOrEmpty(x.Tags))
+                    {
+                        var tags = x.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        return !tags.Any(tag => tag.Equals(downloadCleanerConfig.UnlinkedTargetCategory, StringComparison.InvariantCultureIgnoreCase));
+                    }
+                    return true;
+                }
+
+                return true;
+            })
+            .Cast<object>()
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public override async Task CleanDownloadsAsync(List<object>? downloads, List<CleanCategory> categoriesToClean,
+        HashSet<string> excludedHashes, IReadOnlyList<string> ignoredDownloads)
+    {
+        if (downloads?.Count is null or 0)
+        {
+            return;
+        }
+
+        foreach (RdtTorrentInfo download in downloads)
+        {
+            if (string.IsNullOrEmpty(download.Hash))
+            {
+                continue;
+            }
+
+            if (excludedHashes.Any(x => x.Equals(download.Hash, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                _logger.LogDebug("skip | download is used by an arr | {name}", download.Name);
+                continue;
+            }
+
+            // RDT-Client doesn't support the trackers endpoint
+            if (ignoredDownloads.Count > 0 && download.ShouldIgnore(ignoredDownloads))
+            {
+                _logger.LogInformation("skip | download is ignored | {name}", download.Name);
+                continue;
+            }
+
+            CleanCategory? category = categoriesToClean
+                .FirstOrDefault(x => download.Category.Equals(x.Name, StringComparison.InvariantCultureIgnoreCase));
+
+            if (category is null)
+            {
+                continue;
+            }
+            
+            var downloadCleanerConfig = ContextProvider.Get<DownloadCleanerConfig>(nameof(DownloadCleanerConfig));
+
+            // RDT-Client doesn't support GetTorrentPropertiesAsync, so we skip private checking
+            if (!downloadCleanerConfig.DeletePrivate)
+            {
+                _logger.LogDebug("skip | DeletePrivate is disabled (note: rdt-client doesn't support private torrent detection) | {name}", download.Name);
+                continue;
+            }
+
+            ContextProvider.Set("downloadName", download.Name);
+            ContextProvider.Set("hash", download.Hash);
+
+            SeedingCheckResult result = ShouldCleanDownload(download.Ratio, download.SeedingTime ?? TimeSpan.Zero, category);
+
+            if (!result.ShouldClean)
+            {
+                continue;
+            }
+
+            await _dryRunInterceptor.InterceptAsync(DeleteDownload, download.Hash);
+
+            _logger.LogInformation(
+                "download cleaned | {reason} reached | {name}",
+                result.Reason is CleanReason.MaxRatioReached
+                    ? "MAX_RATIO & MIN_SEED_TIME"
+                    : "MAX_SEED_TIME",
+                download.Name
+            );
+
+            await _eventPublisher.PublishDownloadCleaned(download.Ratio, download.SeedingTime ?? TimeSpan.Zero, category.Name, result.Reason);
+        }
+    }
+
+    public override async Task CreateCategoryAsync(string name)
+    {
+        Dictionary<string, RdtCategory>? existingCategories = await GetCategoriesAsync();
+
+        if (existingCategories.Any(x => x.Value.Name?.Equals(name, StringComparison.InvariantCultureIgnoreCase) ?? false))
+        {
+            return;
+        }
+
+        _logger.LogDebug("Creating category {name}", name);
+
+        await _dryRunInterceptor.InterceptAsync(CreateCategory, name);
+    }
+
+    public override async Task ChangeCategoryForNoHardLinksAsync(List<object>? downloads, HashSet<string> excludedHashes, IReadOnlyList<string> ignoredDownloads)
+    {
+        if (downloads?.Count is null or 0)
+        {
+            return;
+        }
+        
+        var downloadCleanerConfig = ContextProvider.Get<DownloadCleanerConfig>(nameof(DownloadCleanerConfig));
+
+        if (!string.IsNullOrEmpty(downloadCleanerConfig.UnlinkedIgnoredRootDir))
+        {
+            _hardLinkFileService.PopulateFileCounts(downloadCleanerConfig.UnlinkedIgnoredRootDir);
+        }
+
+        foreach (RdtTorrentInfo download in downloads)
+        {
+            if (string.IsNullOrEmpty(download.Hash))
+            {
+                continue;
+            }
+
+            if (excludedHashes.Any(x => x.Equals(download.Hash, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                _logger.LogDebug("skip | download is used by an arr | {name}", download.Name);
+                continue;
+            }
+
+            // RDT-Client doesn't support the trackers endpoint
+            if (ignoredDownloads.Count > 0 && download.ShouldIgnore(ignoredDownloads))
+            {
+                _logger.LogInformation("skip | download is ignored | {name}", download.Name);
+                continue;
+            }
+
+            List<RdtTorrentContent>? files = await GetTorrentContentsAsync(download.Hash);
+
+            if (files is null)
+            {
+                _logger.LogDebug("failed to find files for {name}", download.Name);
+                continue;
+            }
+
+            ContextProvider.Set("downloadName", download.Name);
+            ContextProvider.Set("hash", download.Hash);
+            bool hasHardlinks = false;
+
+            foreach (RdtTorrentContent file in files)
+            {
+                if (!file.Index.HasValue)
+                {
+                    _logger.LogDebug("skip | file index is null for {name}", download.Name);
+                    hasHardlinks = true;
+                    break;
+                }
+
+                string filePath = string.Join(Path.DirectorySeparatorChar, Path.Combine(download.SavePath, file.Name).Split(['\\', '/']));
+
+                if (file.Priority == 0) // Priority 0 means file is not downloaded
+                {
+                    _logger.LogDebug("skip | file is not downloaded | {file}", filePath);
+                    continue;
+                }
+
+                long hardlinkCount = _hardLinkFileService.GetHardLinkCount(filePath, !string.IsNullOrEmpty(downloadCleanerConfig.UnlinkedIgnoredRootDir));
+
+                if (hardlinkCount < 0)
+                {
+                    _logger.LogDebug("skip | could not get file properties | {file}", filePath);
+                    hasHardlinks = true;
+                    break;
+                }
+
+                if (hardlinkCount > 0)
+                {
+                    hasHardlinks = true;
+                    break;
+                }
+            }
+
+            if (hasHardlinks)
+            {
+                _logger.LogDebug("skip | download has hardlinks | {name}", download.Name);
+                continue;
+            }
+
+            await _dryRunInterceptor.InterceptAsync(ChangeCategory, download.Hash, downloadCleanerConfig.UnlinkedTargetCategory);
+            
+            await _eventPublisher.PublishCategoryChanged(download.Category, downloadCleanerConfig.UnlinkedTargetCategory, downloadCleanerConfig.UnlinkedUseTag);
+
+            if (downloadCleanerConfig.UnlinkedUseTag)
+            {
+                _logger.LogInformation("tag added for {name}", download.Name);
+            }
+            else
+            {
+                _logger.LogInformation("category changed for {name}", download.Name);
+                download.Category = downloadCleanerConfig.UnlinkedTargetCategory;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task DeleteDownload(string hash)
+    {
+        await DeleteAsync([hash], deleteFiles: true);
+    }
+
+    protected async Task CreateCategory(string name)
+    {
+        await AddCategoryAsync(name);
+    }
+
+    protected virtual async Task ChangeCategory(string hash, string newCategory)
+    {
+        var downloadCleanerConfig = ContextProvider.Get<DownloadCleanerConfig>(nameof(DownloadCleanerConfig));
+
+        if (downloadCleanerConfig.UnlinkedUseTag)
+        {
+            // RDT-Client doesn't support the addTags endpoint
+            // Fall back to category change instead
+            _logger.LogWarning("RDT-Client doesn't support tags, using category change instead");
+        }
+
+        await SetTorrentCategoryAsync([hash], newCategory);
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceQC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RdtClient/RdtServiceQC.cs
@@ -1,0 +1,39 @@
+using Cleanuparr.Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Features.DownloadClient.RdtClient;
+
+public partial class RdtService
+{
+    /// <inheritdoc/>
+    public override async Task<DownloadCheckResult> ShouldRemoveFromArrQueueAsync(string hash, IReadOnlyList<string> ignoredDownloads)
+    {
+        DownloadCheckResult result = new();
+
+        try
+        {
+            var torrents = await GetTorrentListAsync();
+            RdtTorrentInfo? download = torrents.FirstOrDefault(x => x.Hash == hash);
+
+            if (download is null)
+            {
+                _logger.LogDebug("failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+                return result;
+            }
+
+            result.Found = true;
+
+            // RDT-Client doesn't have a concept of private torrents in the same way
+            result.IsPrivate = false;
+
+            _logger.LogDebug("Queue check for RDT-Client torrent {name} - basic implementation", download.Name);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking torrent {hash} in RDT-Client", hash);
+            return result;
+        }
+    }
+}

--- a/code/frontend/src/app/settings/download-client/download-client-settings.component.ts
+++ b/code/frontend/src/app/settings/download-client/download-client-settings.component.ts
@@ -98,9 +98,9 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
 
     // Initialize type name options
     for (const key of Object.keys(DownloadClientTypeName)) {
-      this.typeNameOptions.push({ 
-        label: key, 
-        value: DownloadClientTypeName[key as keyof typeof DownloadClientTypeName] 
+      this.typeNameOptions.push({
+        label: key,
+        value: DownloadClientTypeName[key as keyof typeof DownloadClientTypeName]
       });
     }
 
@@ -168,7 +168,7 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
   openEditClientModal(client: ClientConfig): void {
     this.modalMode = 'edit';
     this.editingClient = client;
-    
+
     this.clientForm.patchValue({
       name: client.name,
       typeName: client.typeName,
@@ -214,7 +214,7 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
         urlBase: formValue.urlBase,
         enabled: formValue.enabled
       };
-      
+
       this.downloadClientStore.createClient(clientData);
     } else if (this.editingClient) {
       // For updates, create a proper ClientConfig object
@@ -229,9 +229,9 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
         urlBase: formValue.urlBase,
         enabled: formValue.enabled
       };
-      
-      this.downloadClientStore.updateClient({ 
-        id: this.editingClient.id!, 
+
+      this.downloadClientStore.updateClient({
+        id: this.editingClient.id!,
         client: clientConfig
       });
     }
@@ -246,7 +246,7 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
     const checkSavingStatus = () => {
       const saving = this.downloadClientSaving();
       const error = this.downloadClientError();
-      
+
       if (!saving) {
         if (error) {
           this.notificationService.showError(`Operation failed: ${error}`);
@@ -259,7 +259,7 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
         setTimeout(checkSavingStatus, 100);
       }
     };
-    
+
     setTimeout(checkSavingStatus, 100);
   }
 
@@ -274,12 +274,12 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
       acceptButtonStyleClass: 'p-button-danger',
       accept: () => {
         this.downloadClientStore.deleteClient(client.id!);
-        
+
         // Monitor deletion
         const checkDeletionStatus = () => {
           const saving = this.downloadClientSaving();
           const error = this.downloadClientError();
-          
+
           if (!saving) {
             if (error) {
               this.notificationService.showError(`Deletion failed: ${error}`);
@@ -290,7 +290,7 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
             setTimeout(checkDeletionStatus, 100);
           }
         };
-        
+
         setTimeout(checkDeletionStatus, 100);
       }
     });
@@ -312,12 +312,13 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
       case DownloadClientTypeName.Deluge:
       case DownloadClientTypeName.Transmission:
       case DownloadClientTypeName.uTorrent:
+      case DownloadClientTypeName.RdtClient:
         return DownloadClientType.Torrent;
       default:
         throw new Error(`Unknown client type name: ${typeName}`);
     }
   }
-  
+
   /**
    * Handle client type changes to update validation
    */
@@ -326,25 +327,25 @@ export class DownloadClientSettingsComponent implements OnDestroy, CanComponentD
     const hostControl = this.clientForm.get('host');
     const usernameControl = this.clientForm.get('username');
     const urlBaseControl = this.clientForm.get('urlBase');
-    
+
     if (!hostControl || !usernameControl || !urlBaseControl) return;
-    
+
     hostControl.setValidators([
       Validators.required,
       UrlValidators.httpUrl
     ]);
-    
+
     // Clear username value and remove validation for Deluge
     if (clientTypeName === DownloadClientTypeName.Deluge) {
       usernameControl.setValue('');
       usernameControl.clearValidators();
     }
-    
+
     // Set default URL base for Transmission
     if (clientTypeName === DownloadClientTypeName.Transmission) {
       urlBaseControl.setValue('transmission');
     }
-    
+
     // Update validation state
     hostControl.updateValueAndValidity();
     usernameControl.updateValueAndValidity();

--- a/code/frontend/src/app/shared/models/enums.ts
+++ b/code/frontend/src/app/shared/models/enums.ts
@@ -8,6 +8,7 @@ export enum DownloadClientTypeName {
   Deluge = "Deluge",
   Transmission = "Transmission",
   uTorrent = "uTorrent",
+  RdtClient = "RdtClient",
 }
 
 export enum NotificationProviderType {


### PR DESCRIPTION
# Implement RDT-Client (Real-Debrid Torrent Client) as a new download client type with direct HTTP API integration.

##  Implementation details:

  - Direct HTTP calls to RDT-Client's qBittorrent-compatible API (/api/v2)
  - Support for both authenticated and non-authenticated configurations
  - Cookie-based session management using default HttpClient behavior
  - Only uses the endpoints RDT-Client's API implementation

##  Backend changes:
  - Add RdtService with partial classes for Download Cleaner (DC), Content
    Blocker (CB), and Queue Checker (QC) operations
  - Implement core operations: login, health check, torrent listing, file
    operations, category management, and deletion
  - Add RdtExtensions for filtering ignored downloads by hash, category, and
    comma-separated tags
  - Update DownloadServiceFactory to create RdtService instances
  - Add RdtClient to DownloadClientTypeName enum

 ## Frontend changes:
  - Add RDT-Client option to download client settings UI
  - Update TypeScript enums to include RdtClient

  ## API endpoints implemented:
  - /api/v2/auth/login (POST)
  - /api/v2/app/version (GET)
  - /api/v2/torrents/info (GET)
  - /api/v2/torrents/files (GET)
  - /api/v2/torrents/categories (GET)
  - /api/v2/torrents/createCategory (POST)
  - /api/v2/torrents/setCategory (POST)
  - /api/v2/torrents/delete (POST)
