### PR TITLE
Fix reveal button being pressed on Enter instead of login

### DIFF
--- a/code/frontend/src/app/ui/input/input.component.html
+++ b/code/frontend/src/app/ui/input/input.component.html
@@ -2,7 +2,7 @@
   <label class="input-label">
     {{ label() }}
     @if (helpKey()) {
-      <button type="button" class="field-help-btn" (click)="onHelpClick($event)" aria-label="Open documentation" tabindex="-1">
+      <button type="button" class="field-help-btn" (click)="onHelpClick($event)" [attr.aria-label]="'Open documentation for ' + label()">
         <ng-icon name="tablerQuestionMark" size="14" />
       </button>
     }
@@ -22,7 +22,7 @@
     (blur)="blurred.emit($event)"
   />
   @if (type() === 'password') {
-    <button type="button" class="input-eye-btn" (click)="toggleSecret($event)" tabindex="-1" aria-label="Toggle visibility">
+    <button type="button" class="input-eye-btn" (click)="toggleSecret($event)" [attr.aria-label]="showSecret() ? 'Hide password' : 'Show password'">
       <ng-icon [name]="showSecret() ? 'tablerEyeOff' : 'tablerEye'" size="16" />
     </button>
   }


### PR DESCRIPTION
Relates to #481

## Summary by Sourcery

Bug Fixes:
- Prevent the help and password-visibility buttons in input fields from acting as submit buttons when pressing Enter in a form.