### PR TITLE
Enforce authorize attribute explicitely

### DIFF
--- a/code/backend/Cleanuparr.Api/Controllers/ApiDocumentationController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/ApiDocumentationController.cs
@@ -1,9 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api")]
+[Authorize]
 public class ApiDocumentationController : ControllerBase
 {
     [HttpGet]

--- a/code/backend/Cleanuparr.Api/Controllers/EventsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/EventsController.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Cleanuparr.Domain.Enums;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Events;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,6 +10,7 @@ namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class EventsController : ControllerBase
 {
     private readonly EventsContext _context;

--- a/code/backend/Cleanuparr.Api/Controllers/HealthCheckController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/HealthCheckController.cs
@@ -1,4 +1,5 @@
 using Cleanuparr.Infrastructure.Health;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Cleanuparr.Api.Controllers;
@@ -8,6 +9,7 @@ namespace Cleanuparr.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/health")]
+[Authorize]
 public class HealthCheckController : ControllerBase
 {
     private readonly ILogger<HealthCheckController> _logger;

--- a/code/backend/Cleanuparr.Api/Controllers/HealthController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/HealthController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -8,6 +9,7 @@ namespace Cleanuparr.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("[controller]")]
+[Authorize]
 public class HealthController : ControllerBase
 {
     private readonly HealthCheckService _healthCheckService;
@@ -23,6 +25,7 @@ public class HealthController : ControllerBase
     /// Basic liveness probe - checks if the application is running
     /// Used by Docker HEALTHCHECK and Kubernetes liveness probes
     /// </summary>
+    [AllowAnonymous]
     [HttpGet]
     [Route("/health")]
     public async Task<IActionResult> GetHealth()
@@ -47,6 +50,7 @@ public class HealthController : ControllerBase
     /// Readiness probe - checks if the application is ready to serve traffic
     /// Used by Kubernetes readiness probes
     /// </summary>
+    [AllowAnonymous]
     [HttpGet]
     [Route("/health/ready")]
     public async Task<IActionResult> GetReadiness()

--- a/code/backend/Cleanuparr.Api/Controllers/JobsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/JobsController.cs
@@ -2,12 +2,14 @@ using Cleanuparr.Api.Models;
 using Cleanuparr.Domain.Enums;
 using Cleanuparr.Infrastructure.Models;
 using Cleanuparr.Infrastructure.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class JobsController : ControllerBase
 {
     private readonly IJobManagementService _jobManagementService;

--- a/code/backend/Cleanuparr.Api/Controllers/ManualEventsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/ManualEventsController.cs
@@ -1,6 +1,7 @@
 using Cleanuparr.Domain.Enums;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Events;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,6 +9,7 @@ namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class ManualEventsController : ControllerBase
 {
     private readonly EventsContext _context;

--- a/code/backend/Cleanuparr.Api/Controllers/StatsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/StatsController.cs
@@ -1,4 +1,5 @@
 using Cleanuparr.Infrastructure.Stats;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Cleanuparr.Api.Controllers;
@@ -8,6 +9,7 @@ namespace Cleanuparr.Api.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class StatsController : ControllerBase
 {
     private readonly ILogger<StatsController> _logger;

--- a/code/backend/Cleanuparr.Api/Controllers/StatusController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/StatusController.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Cleanuparr.Domain.Enums;
 using Cleanuparr.Infrastructure.Features.Arr.Interfaces;
 using Cleanuparr.Persistence;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,6 +10,7 @@ namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class StatusController : ControllerBase
 {
     private readonly ILogger<StatusController> _logger;

--- a/code/backend/Cleanuparr.Api/Controllers/StrikesController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/StrikesController.cs
@@ -1,6 +1,7 @@
 using Cleanuparr.Domain.Enums;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.State;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,6 +9,7 @@ namespace Cleanuparr.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class StrikesController : ControllerBase
 {
     private readonly EventsContext _context;

--- a/code/backend/Cleanuparr.Api/Features/Arr/Controllers/ArrConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/Arr/Controllers/ArrConfigController.cs
@@ -4,6 +4,7 @@ using Cleanuparr.Infrastructure.Features.Arr.Dtos;
 using Cleanuparr.Infrastructure.Features.Arr.Interfaces;
 using Cleanuparr.Persistence;
 using Mapster;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,6 +12,7 @@ namespace Cleanuparr.Api.Features.Arr.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class ArrConfigController : ControllerBase
 {
     private readonly ILogger<ArrConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/BlacklistSync/Controllers/BlacklistSyncConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/BlacklistSync/Controllers/BlacklistSyncConfigController.cs
@@ -6,6 +6,7 @@ using Cleanuparr.Domain.Enums;
 using Cleanuparr.Infrastructure.Services.Interfaces;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration.BlacklistSync;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace Cleanuparr.Api.Features.BlacklistSync.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class BlacklistSyncConfigController : ControllerBase
 {
     private readonly ILogger<BlacklistSyncConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/DownloadCleanerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/DownloadCleanerConfigController.cs
@@ -9,6 +9,7 @@ using Cleanuparr.Infrastructure.Utilities;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration;
 using Cleanuparr.Persistence.Models.Configuration.DownloadCleaner;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,7 @@ namespace Cleanuparr.Api.Features.DownloadCleaner.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class DownloadCleanerConfigController : ControllerBase
 {
     private readonly ILogger<DownloadCleanerConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/DownloadClient/Controllers/DownloadClientController.cs
+++ b/code/backend/Cleanuparr.Api/Features/DownloadClient/Controllers/DownloadClientController.cs
@@ -5,6 +5,7 @@ using Cleanuparr.Api.Features.DownloadClient.Contracts.Requests;
 using Cleanuparr.Infrastructure.Features.DownloadClient;
 using Cleanuparr.Infrastructure.Http.DynamicHttpClientSystem;
 using Cleanuparr.Persistence;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +13,7 @@ namespace Cleanuparr.Api.Features.DownloadClient.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class DownloadClientController : ControllerBase
 {
     private readonly ILogger<DownloadClientController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/General/Controllers/GeneralConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/General/Controllers/GeneralConfigController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 
 using Cleanuparr.Api.Features.General.Contracts.Requests;
 using Cleanuparr.Persistence;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -12,6 +13,7 @@ namespace Cleanuparr.Api.Features.General.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class GeneralConfigController : ControllerBase
 {
     private readonly ILogger<GeneralConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/MalwareBlocker/Controllers/MalwareBlockerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/MalwareBlocker/Controllers/MalwareBlockerConfigController.cs
@@ -8,6 +8,7 @@ using Cleanuparr.Infrastructure.Utilities;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration;
 using Cleanuparr.Persistence.Models.Configuration.MalwareBlocker;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ namespace Cleanuparr.Api.Features.MalwareBlocker.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class MalwareBlockerConfigController : ControllerBase
 {
     private readonly ILogger<MalwareBlockerConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/Notifications/Controllers/NotificationProvidersController.cs
+++ b/code/backend/Cleanuparr.Api/Features/Notifications/Controllers/NotificationProvidersController.cs
@@ -11,6 +11,7 @@ using Cleanuparr.Infrastructure.Features.Notifications.Telegram;
 using Cleanuparr.Infrastructure.Features.Notifications.Gotify;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration.Notification;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -18,6 +19,7 @@ namespace Cleanuparr.Api.Features.Notifications.Controllers;
 
 [ApiController]
 [Route("api/configuration/notification_providers")]
+[Authorize]
 public sealed class NotificationProvidersController : ControllerBase
 {
     private readonly ILogger<NotificationProvidersController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/QueueCleaner/Controllers/QueueCleanerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/QueueCleaner/Controllers/QueueCleanerConfigController.cs
@@ -7,6 +7,7 @@ using Cleanuparr.Infrastructure.Utilities;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration;
 using Cleanuparr.Persistence.Models.Configuration.QueueCleaner;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -15,6 +16,7 @@ namespace Cleanuparr.Api.Features.QueueCleaner.Controllers;
 
 [ApiController]
 [Route("api/configuration")]
+[Authorize]
 public sealed class QueueCleanerConfigController : ControllerBase
 {
     private readonly ILogger<QueueCleanerConfigController> _logger;

--- a/code/backend/Cleanuparr.Api/Features/QueueCleaner/Controllers/QueueRulesController.cs
+++ b/code/backend/Cleanuparr.Api/Features/QueueCleaner/Controllers/QueueRulesController.cs
@@ -3,6 +3,7 @@ using Cleanuparr.Domain.Exceptions;
 using Cleanuparr.Infrastructure.Services.Interfaces;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration.QueueCleaner;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -11,6 +12,7 @@ namespace Cleanuparr.Api.Features.QueueCleaner.Controllers;
 
 [ApiController]
 [Route("api/queue-rules")]
+[Authorize]
 public class QueueRulesController : ControllerBase
 {
     private readonly ILogger<QueueRulesController> _logger;


### PR DESCRIPTION
Authorization was already enforced through a policy (see [here](https://github.com/Cleanuparr/Cleanuparr/blob/57fef26726f2d328b3a43278ed166de281471439/code/backend/Cleanuparr.Api/DependencyInjection/AuthDI.cs#L80)), but this PR aims to make it more explicit.

## Summary by Sourcery

Enforce authorization on all API controllers while explicitly allowing anonymous access for health probe endpoints.

New Features:
- Add authorization requirement to all API and configuration controllers via the Authorize attribute.

Enhancements:
- Explicitly mark liveness and readiness health endpoints as anonymously accessible to support external health probes.