### PR TITLE
Revoke all refresh tokens on password change

### DIFF
--- a/code/backend/Cleanuparr.Api/Features/Auth/Controllers/AccountController.cs
+++ b/code/backend/Cleanuparr.Api/Features/Auth/Controllers/AccountController.cs
@@ -66,8 +66,10 @@ public sealed class AccountController : ControllerBase
                 return BadRequest(new { error = "Current password is incorrect" });
             }
 
+            DateTime now = DateTime.UtcNow;
+
             user.PasswordHash = _passwordService.HashPassword(request.NewPassword);
-            user.UpdatedAt = DateTime.UtcNow;
+            user.UpdatedAt = now;
 
             // Revoke all existing refresh tokens so old sessions can't be reused
             var activeTokens = await _usersContext.RefreshTokens
@@ -76,7 +78,7 @@ public sealed class AccountController : ControllerBase
 
             foreach (var token in activeTokens)
             {
-                token.RevokedAt = DateTime.UtcNow;
+                token.RevokedAt = now;
             }
 
             await _usersContext.SaveChangesAsync();


### PR DESCRIPTION
## Summary by Sourcery

Revoke all existing refresh tokens when a user changes their password to prevent reuse of old sessions.

Bug Fixes:
- Invalidate any active refresh tokens upon password change so compromised or stale sessions cannot remain valid.

Enhancements:
- Tighten account security by ensuring password changes force reauthentication across all sessions.