### PR TITLE
Fix chip input not displaying the proper error message

### DIFF
--- a/code/frontend/src/app/ui/chip-input/chip-input.component.html
+++ b/code/frontend/src/app/ui/chip-input/chip-input.component.html
@@ -30,10 +30,10 @@
     <button class="chip-add" type="button" (click)="commitInput()" aria-label="Add item">+</button>
   }
 </div>
-@if (error()) {
-  <span class="chip-error">{{ error() }}</span>
-} @else if (uncommittedError()) {
+@if (uncommittedError()) {
   <span class="chip-error">{{ uncommittedError() }}</span>
+} @else if (error()) {
+  <span class="chip-error">{{ error() }}</span>
 } @else if (hint()) {
   <span class="chip-hint">{{ hint() }}</span>
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the chip input to show the appropriate uncommitted error message instead of being overridden by the general error state.