### PR TITLE
Add failed screen before login when the API can not be reached

### DIFF
--- a/code/frontend/src/app/core/auth/auth.service.ts
+++ b/code/frontend/src/app/core/auth/auth.service.ts
@@ -49,6 +49,7 @@ export class AuthService {
   private readonly _isSetupComplete = signal(false);
   private readonly _plexLinked = signal(false);
   private readonly _isLoading = signal(true);
+  private readonly _connectionError = signal(false);
   private readonly _oidcEnabled = signal(false);
   private readonly _oidcProviderName = signal('');
   private readonly _oidcExclusiveMode = signal(false);
@@ -57,6 +58,7 @@ export class AuthService {
   readonly isSetupComplete = this._isSetupComplete.asReadonly();
   readonly plexLinked = this._plexLinked.asReadonly();
   readonly isLoading = this._isLoading.asReadonly();
+  readonly connectionError = this._connectionError.asReadonly();
   readonly oidcEnabled = this._oidcEnabled.asReadonly();
   readonly oidcProviderName = this._oidcProviderName.asReadonly();
   readonly oidcExclusiveMode = this._oidcExclusiveMode.asReadonly();
@@ -68,6 +70,7 @@ export class AuthService {
   checkStatus(): Observable<AuthStatus> {
     return this.http.get<AuthStatus>('/api/auth/status').pipe(
       tap((status) => {
+        this._connectionError.set(false);
         this._isSetupComplete.set(status.setupCompleted);
         this._plexLinked.set(status.plexLinked);
         this._oidcEnabled.set(status.oidcEnabled ?? false);
@@ -106,6 +109,7 @@ export class AuthService {
         this._isLoading.set(false);
       }),
       catchError(() => {
+        this._connectionError.set(true);
         this._isLoading.set(false);
         return of({ setupCompleted: false, plexLinked: false });
       }),
@@ -129,6 +133,12 @@ export class AuthService {
     return this.http.post<{ message: string }>('/api/auth/setup/complete', {}).pipe(
       tap(() => this._isSetupComplete.set(true)),
     );
+  }
+
+  retryConnection(): Observable<AuthStatus> {
+    this._connectionError.set(false);
+    this._isLoading.set(true);
+    return this.checkStatus();
   }
 
   // Login flow

--- a/code/frontend/src/app/features/auth/setup/setup.component.html
+++ b/code/frontend/src/app/features/auth/setup/setup.component.html
@@ -1,3 +1,18 @@
+@if (connectionError() || retrying()) {
+  <app-empty-state
+    heading="Could not connect to server"
+    description="Failed to connect to the server. Please check that the server is running and try again."
+  >
+    <app-button variant="primary" size="sm" [disabled]="retrying()" (clicked)="retryConnection()">
+      @if (retrying()) {
+        <app-spinner size="sm" />
+      } @else {
+        Retry
+      }
+    </app-button>
+  </app-empty-state>
+} @else {
+
 <h2 class="setup-title">Initial Setup</h2>
 
 <div class="steps-indicator">
@@ -235,4 +250,6 @@
       </app-button>
     </div>
   </div>
+}
+
 }

--- a/code/frontend/src/app/features/auth/setup/setup.component.ts
+++ b/code/frontend/src/app/features/auth/setup/setup.component.ts
@@ -1,17 +1,18 @@
 import { Component, ChangeDetectionStrategy, inject, signal, computed, viewChild, effect, afterNextRender, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { ButtonComponent, InputComponent, SpinnerComponent } from '@ui';
+import { ButtonComponent, InputComponent, SpinnerComponent, EmptyStateComponent } from '@ui';
 import { AuthService } from '@core/auth/auth.service';
 import { ToastService } from '@core/services/toast.service';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import { tablerCheck, tablerCopy, tablerShieldLock } from '@ng-icons/tabler-icons';
 import { QRCodeComponent } from 'angularx-qrcode';
+import { forkJoin, timer } from 'rxjs';
 
 @Component({
   selector: 'app-setup',
   standalone: true,
-  imports: [FormsModule, ButtonComponent, InputComponent, SpinnerComponent, NgIconComponent, QRCodeComponent],
+  imports: [FormsModule, ButtonComponent, InputComponent, SpinnerComponent, EmptyStateComponent, NgIconComponent, QRCodeComponent],
   templateUrl: './setup.component.html',
   styleUrl: './setup.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,6 +22,9 @@ export class SetupComponent implements OnDestroy {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
+
+  readonly connectionError = this.auth.connectionError;
+  readonly retrying = signal(false);
 
   currentStep = signal(1);
   loading = signal(false);
@@ -83,6 +87,16 @@ export class SetupComponent implements OnDestroy {
       const step = this.currentStep();
       if (step === 2) {
         setTimeout(() => this.verificationInput()?.focus());
+      }
+    });
+  }
+
+  retryConnection(): void {
+    this.retrying.set(true);
+    forkJoin([this.auth.retryConnection(), timer(500)]).subscribe(() => {
+      this.retrying.set(false);
+      if (this.auth.isSetupComplete()) {
+        this.router.navigate(['/auth/login']);
       }
     });
   }


### PR DESCRIPTION
## Summary by Sourcery

Display a connection error state during initial setup when the authentication API cannot be reached and allow the user to retry the connection before proceeding to login or setup.

New Features:
- Show an empty-state error screen in the setup flow when the server connection fails before login.
- Provide a retry action that rechecks authentication status and navigates to login if setup is already complete.

Enhancements:
- Track server connection errors and loading state within the auth service and expose them to the setup component.