### PR TITLE
Fix test workflows cancelling each other

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: E2E Tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 
 # Cancel in-progress runs for the same PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: Tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

Adjust GitHub Actions concurrency groups for test workflows to prevent separate workflows from canceling each other.

CI:
- Set a distinct concurrency group name for E2E tests to avoid conflicts with other workflows.
- Set a distinct concurrency group name for general tests to avoid cross-workflow cancellation.