### PR TITLE
Fix PR build bot reacting to all comments

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -51,7 +51,7 @@ jobs:
                 content: 'eyes'
               });
             } catch (e) {
-              console.log(`Could not add reaction: ${e.message}`);
+              console.log(`Could not add reaction: ${e}`);
             }
 
             // Fetch PR details


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust PR build workflow so the bot reacts to comments only after validating the command and user permissions, and logs reaction failures without breaking the workflow.