### PR TITLE
Fix animated counter having negative values

### DIFF
--- a/code/frontend/src/app/ui/animated-counter/animated-counter.component.ts
+++ b/code/frontend/src/app/ui/animated-counter/animated-counter.component.ts
@@ -4,6 +4,7 @@ import {
   input,
   signal,
   effect,
+  untracked,
   OnDestroy,
   PLATFORM_ID,
   inject,
@@ -61,7 +62,7 @@ export class AnimatedCounterComponent implements OnDestroy {
   private animateTo(target: number, duration: number): void {
     cancelAnimationFrame(this.animationId);
 
-    const start = this.displayValue();
+    const start = untracked(() => this.displayValue());
     const diff = target - start;
     if (diff === 0) return;
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix animated counter initialization so it uses an untracked starting value when computing animation differences, preventing negative counts.