### PR TITLE
Fix Transmission ratio not being fetched

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionItemWrapperTests.cs
@@ -149,21 +149,17 @@ public class TransmissionItemWrapperTests
     }
 
     [Theory]
-    [InlineData(1024L, 512L, 2.0)] // Uploaded more than downloaded
-    [InlineData(512L, 1024L, 0.5)] // Uploaded less than downloaded
-    [InlineData(1024L, 1024L, 1.0)] // Equal
-    [InlineData(0L, 1024L, 0.0)] // No upload
-    [InlineData(1024L, 0L, 0.0)] // No download
-    [InlineData(null, 1024L, 0.0)] // Null upload
-    [InlineData(1024L, null, 0.0)] // Null download
-    [InlineData(null, null, 0.0)] // Both null
-    public void Ratio_ReturnsCorrectValue(long? uploadedEver, long? downloadedEver, double expected)
+    [InlineData(2.0, 2.0)]
+    [InlineData(0.5, 0.5)]
+    [InlineData(1.0, 1.0)]
+    [InlineData(0.0, 0.0)]
+    [InlineData(null, 0.0)]
+    public void Ratio_ReturnsCorrectValue(double? uploadRatio, double expected)
     {
         // Arrange
         var torrentInfo = new TorrentInfo
         {
-            UploadedEver = uploadedEver,
-            DownloadedEver = downloadedEver
+            uploadRatio = uploadRatio
         };
         var wrapper = new TransmissionItemWrapper(torrentInfo);
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionItemWrapper.cs
@@ -33,9 +33,7 @@ public sealed class TransmissionItemWrapper : ITorrentItemWrapper
 
     public long DownloadSpeed => Info.RateDownload ?? 0;
     
-    public double Ratio => (Info.UploadedEver ?? 0) > 0 && (Info.DownloadedEver ?? 0) > 0
-        ? (Info.UploadedEver ?? 0) / (double)(Info.DownloadedEver ?? 1)
-        : 0.0;
+    public double Ratio => Info.uploadRatio ?? 0.0;
 
     public long Eta => Info.Eta ?? 0;
     


### PR DESCRIPTION
Relates to #516

## Summary by Sourcery

Use the Transmission torrent info's reported upload ratio instead of recomputing it from uploaded and downloaded bytes.

Bug Fixes:
- Correct ratio calculation by reading the uploadRatio field reported by Transmission rather than deriving it from uploaded/downloaded bytes.

Tests:
- Update TransmissionItemWrapper ratio tests to validate values based on the uploadRatio field and handle nullable ratios.