### PR TITLE
Fix dashboard logs initial order

### DIFF
--- a/code/frontend/src/app/core/realtime/app-hub.service.ts
+++ b/code/frontend/src/app/core/realtime/app-hub.service.ts
@@ -45,7 +45,7 @@ export class AppHubService extends HubService {
 
     // Bulk initial logs
     connection.on('LogsReceived', (logs: LogEntry[]) => {
-      this._logs.set(logs);
+      this._logs.set([...logs].reverse());
     });
 
     // Single event


### PR DESCRIPTION
Relates to #505

## Summary by Sourcery

Bug Fixes:
- Reverse the initial batch of received logs so the dashboard displays them in the expected chronological order.