### PR TITLE
Fix Seeker being scheduled when disabled

### DIFF
--- a/code/backend/Cleanuparr.Api/Features/Seeker/Controllers/SeekerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/Seeker/Controllers/SeekerConfigController.cs
@@ -140,8 +140,22 @@ public sealed class SeekerConfigController : ControllerBase
 
             await _dataContext.SaveChangesAsync();
 
-            // Update Quartz trigger if SearchInterval changed
-            if (config.SearchInterval != previousInterval)
+            // Start/stop Seeker based on SearchEnabled toggle
+            if (config.SearchEnabled != previousSearchEnabled)
+            {
+                if (config.SearchEnabled)
+                {
+                    _logger.LogInformation("SearchEnabled turned on, starting Seeker job");
+                    await _jobManagementService.StartJob(JobType.Seeker, null, config.ToCronExpression());
+                }
+                else
+                {
+                    _logger.LogInformation("SearchEnabled turned off, stopping Seeker job");
+                    await _jobManagementService.StopJob(JobType.Seeker);
+                }
+            }
+            // Update Quartz trigger if SearchInterval changed (only while search is enabled)
+            else if (config.SearchEnabled && config.SearchInterval != previousInterval)
             {
                 _logger.LogInformation("Search interval changed from {Old} to {New} minutes, updating Seeker schedule",
                     previousInterval, config.SearchInterval);

--- a/code/backend/Cleanuparr.Api/Jobs/BackgroundJobManager.cs
+++ b/code/backend/Cleanuparr.Api/Jobs/BackgroundJobManager.cs
@@ -185,7 +185,10 @@ public class BackgroundJobManager : IHostedService
     public async Task RegisterSeekerJob(SeekerConfig config, CancellationToken cancellationToken = default)
     {
         await AddJobWithoutTrigger<SeekerJob>(cancellationToken);
-        await AddTriggersForJob<SeekerJob>(config.ToCronExpression(), cancellationToken);
+        if (config.SearchEnabled)
+        {
+            await AddTriggersForJob<SeekerJob>(config.ToCronExpression(), cancellationToken);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary by Sourcery

Ensure the Seeker background job is only scheduled and run when explicitly enabled in configuration.

Bug Fixes:
- Prevent the Seeker job from being scheduled or rescheduled when search is disabled.

Enhancements:
- Start or stop the Seeker job immediately when the SearchEnabled setting is toggled, and only update its schedule when it remains enabled.