### PR TITLE
Fix round robin toggle not changing state correctly

### DIFF
--- a/code/frontend/src/app/features/settings/seeker/seeker.component.html
+++ b/code/frontend/src/app/features/settings/seeker/seeker.component.html
@@ -61,7 +61,8 @@
         <app-toggle label="Use Custom Format Score" [(checked)]="useCustomFormatScore"
           hint="Search for upgrades when a file's custom format score is below the quality profile's cutoff format score"
           helpKey="seeker:useCustomFormatScore" />
-        <app-toggle label="Round Robin" [checked]="useRoundRobin()" (checkedChange)="toggleRoundRobin($event)"
+        <app-toggle label="Round Robin" [(checked)]="useRoundRobin"
+          [beforeChange]="confirmRoundRobin"
           hint="Process one instance per run to spread indexer load"
           helpKey="seeker:useRoundRobin" />
         <app-number-input

--- a/code/frontend/src/app/features/settings/seeker/seeker.component.ts
+++ b/code/frontend/src/app/features/settings/seeker/seeker.component.ts
@@ -152,25 +152,17 @@ export class SeekerComponent implements OnInit, HasPendingChanges {
     this.loadConfig();
   }
 
-  async toggleRoundRobin(newValue: boolean): Promise<void> {
+  readonly confirmRoundRobin = async (newValue: boolean): Promise<boolean> => {
     if (!newValue) {
-      const confirmed = await this.confirm.confirm({
+      return this.confirm.confirm({
         title: 'Disable Round Robin',
         message: 'Disabling round robin will trigger a search for each enabled arr instance per run. This could result in too many requests to your indexers and potentially get you banned.',
         confirmLabel: 'Disable',
         destructive: true,
       });
-      if (!confirmed) {
-        // The toggle already flipped its internal state to false.
-        // Sync our signal to false first, then restore to true in the next microtask
-        // so Angular detects an actual change and pushes it back to the toggle.
-        this.useRoundRobin.set(false);
-        queueMicrotask(() => this.useRoundRobin.set(true));
-        return;
-      }
     }
-    this.useRoundRobin.set(newValue);
-  }
+    return true;
+  };
 
   toggleInstance(index: number): void {
     this.instances.update(instances => {

--- a/code/frontend/src/app/ui/toggle/toggle.component.ts
+++ b/code/frontend/src/app/ui/toggle/toggle.component.ts
@@ -17,12 +17,30 @@ export class ToggleComponent {
   disabled = input(false);
   hint = input<string>();
   helpKey = input<string>();
+  beforeChange = input<(newValue: boolean) => Promise<boolean> | boolean>();
   checked = model(false);
 
-  toggle(): void {
-    if (!this.disabled()) {
-      this.checked.set(!this.checked());
+  private pending = false;
+
+  async toggle(): Promise<void> {
+    if (this.disabled() || this.pending) return;
+
+    const newValue = !this.checked();
+    const guard = this.beforeChange();
+
+    if (guard) {
+      this.pending = true;
+      try {
+        const allowed = await guard(newValue);
+        if (!allowed) return;
+      } catch {
+        return;
+      } finally {
+        this.pending = false;
+      }
     }
+
+    this.checked.set(newValue);
   }
 
   onKeydown(event: KeyboardEvent): void {


### PR DESCRIPTION
## Summary by Sourcery

Guard the Round Robin setting toggle behind a confirmation step using a reusable pre-change hook on the shared toggle component.

New Features:
- Add a generic beforeChange hook to the shared toggle component to allow async validation or confirmation before changing state.

Bug Fixes:
- Ensure the Round Robin setting correctly reflects the confirmed state by binding directly to the model and using the new pre-change confirmation hook instead of manually reverting the toggle.

Enhancements:
- Refactor the Round Robin setting in the seeker settings to use two-way binding with the toggle component and the new confirmation hook for clearer and more reliable state management.