### PR TITLE
Fix disabled arr instances being processed in some cases

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure/Features/Jobs/GenericHandler.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Jobs/GenericHandler.cs
@@ -105,7 +105,7 @@ public abstract class GenericHandler : IHandler
             return;
         }
 
-        foreach (ArrInstance arrInstance in config.Instances)
+        foreach (ArrInstance arrInstance in enabledInstances)
         {
             try
             {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent disabled Arr instances from being processed during job execution.