### PR TITLE
Fix qBittorrent tracker fetching

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
@@ -148,7 +148,7 @@ public partial class QBitService : DownloadService, IQBitService
     private async Task<IReadOnlyList<TorrentTracker>> GetTrackersAsync(string hash)
     {
         return (await _client.GetTorrentTrackersAsync(hash))
-            .Where(x => x.Url.Contains("**"))
+            .Where(x => !x.Url.Contains("**"))
             .ToList();
     }
     


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix tracker URL filtering so that trackers containing a specific pattern are excluded instead of included.