### PR TITLE
Fix log config inputs not allowing for zero

### DIFF
--- a/code/frontend/src/app/features/settings/general/general-settings.component.html
+++ b/code/frontend/src/app/features/settings/general/general-settings.component.html
@@ -109,15 +109,15 @@
       <div class="form-divider"></div>
 
       <div class="form-row">
-        <app-number-input label="Rolling Size" [(value)]="logRollingSizeMB" [min]="1" [max]="100" suffix="MB"
+        <app-number-input label="Rolling Size" [(value)]="logRollingSizeMB" [min]="0" [max]="100" suffix="MB"
           hint="Maximum size of each log file in megabytes (0 = disabled)"
           [error]="logRollingSizeError()"
           helpKey="general:log.rollingSizeMB" />
-        <app-number-input label="Retained Files" [(value)]="logRetainedFileCount" [min]="1" [max]="50"
+        <app-number-input label="Retained Files" [(value)]="logRetainedFileCount" [min]="0" [max]="50"
           hint="Number of old log files to retain (0 = unlimited)"
           [error]="logRetainedFileCountError()"
           helpKey="general:log.retainedFileCount" />
-        <app-number-input label="Time Limit" [(value)]="logTimeLimitHours" [min]="1" [max]="1440" suffix="hours"
+        <app-number-input label="Time Limit" [(value)]="logTimeLimitHours" [min]="0" [max]="1440" suffix="hours"
           hint="Maximum age of old log files in hours (0 = unlimited)"
           [error]="logTimeLimitError()"
           helpKey="general:log.timeLimitHours" />
@@ -130,11 +130,11 @@
         helpKey="general:log.archiveEnabled" />
       @if (logArchiveEnabled()) {
         <div class="form-row">
-          <app-number-input label="Archive Retained Count" [(value)]="logArchiveRetainedCount" [min]="1" [max]="100"
+          <app-number-input label="Archive Retained Count" [(value)]="logArchiveRetainedCount" [min]="0" [max]="100"
             hint="Number of archive files to retain (0 = unlimited)"
             [error]="logArchiveRetainedError()"
             helpKey="general:log.archiveRetainedCount" />
-          <app-number-input label="Archive Time Limit" [(value)]="logArchiveTimeLimitHours" [min]="1" [max]="1440" suffix="hours"
+          <app-number-input label="Archive Time Limit" [(value)]="logArchiveTimeLimitHours" [min]="0" [max]="1440" suffix="hours"
             hint="Maximum age of archive files in hours (0 = unlimited)"
             [error]="logArchiveTimeLimitError()"
             helpKey="general:log.archiveTimeLimitHours" />

--- a/code/frontend/src/app/features/settings/general/general-settings.component.ts
+++ b/code/frontend/src/app/features/settings/general/general-settings.component.ts
@@ -101,7 +101,7 @@ export class GeneralSettingsComponent implements OnInit, HasPendingChanges {
   readonly logRollingSizeError = computed(() => {
     const v = this.logRollingSizeMB();
     if (v == null) return 'This field is required';
-    if (v < 1) return 'Minimum value is 1';
+    if (v < 0) return 'Minimum value is 0';
     if (v > 100) return 'Maximum value is 100 MB';
     return undefined;
   });
@@ -117,7 +117,7 @@ export class GeneralSettingsComponent implements OnInit, HasPendingChanges {
   readonly logTimeLimitError = computed(() => {
     const v = this.logTimeLimitHours();
     if (v == null) return 'This field is required';
-    if (v < 1) return 'Minimum value is 1';
+    if (v < 0) return 'Minimum value is 0';
     if (v > 1440) return 'Maximum value is 1440 hours (60 days)';
     return undefined;
   });
@@ -127,14 +127,20 @@ export class GeneralSettingsComponent implements OnInit, HasPendingChanges {
     if (v == null) return 'This field is required';
     if (v < 0) return 'Minimum value is 0';
     if (v > 100) return 'Maximum value is 100';
+    if (this.logArchiveEnabled() && v === 0 && this.logArchiveTimeLimitHours() === 0) {
+      return 'Retained count and time limit cannot both be 0 when archiving is enabled';
+    }
     return undefined;
   });
 
   readonly logArchiveTimeLimitError = computed(() => {
     const v = this.logArchiveTimeLimitHours();
     if (v == null) return 'This field is required';
-    if (v < 1) return 'Minimum value is 1';
+    if (v < 0) return 'Minimum value is 0';
     if (v > 1440) return 'Maximum value is 1440 hours (60 days)';
+    if (this.logArchiveEnabled() && v === 0 && this.logArchiveRetainedCount() === 0) {
+      return 'Retained count and time limit cannot both be 0 when archiving is enabled';
+    }
     return undefined;
   });
 

--- a/code/frontend/src/app/features/settings/general/general-settings.component.ts
+++ b/code/frontend/src/app/features/settings/general/general-settings.component.ts
@@ -122,15 +122,18 @@ export class GeneralSettingsComponent implements OnInit, HasPendingChanges {
     return undefined;
   });
 
+  readonly logArchiveRetentionBothZeroError = computed(() =>
+    this.logArchiveEnabled() && this.logArchiveRetainedCount() === 0 && this.logArchiveTimeLimitHours() === 0
+      ? 'Retained count and time limit cannot both be 0 when archiving is enabled'
+      : undefined
+  );
+
   readonly logArchiveRetainedError = computed(() => {
     const v = this.logArchiveRetainedCount();
     if (v == null) return 'This field is required';
     if (v < 0) return 'Minimum value is 0';
     if (v > 100) return 'Maximum value is 100';
-    if (this.logArchiveEnabled() && v === 0 && this.logArchiveTimeLimitHours() === 0) {
-      return 'Retained count and time limit cannot both be 0 when archiving is enabled';
-    }
-    return undefined;
+    return this.logArchiveRetentionBothZeroError();
   });
 
   readonly logArchiveTimeLimitError = computed(() => {
@@ -138,10 +141,7 @@ export class GeneralSettingsComponent implements OnInit, HasPendingChanges {
     if (v == null) return 'This field is required';
     if (v < 0) return 'Minimum value is 0';
     if (v > 1440) return 'Maximum value is 1440 hours (60 days)';
-    if (this.logArchiveEnabled() && v === 0 && this.logArchiveRetainedCount() === 0) {
-      return 'Retained count and time limit cannot both be 0 when archiving is enabled';
-    }
-    return undefined;
+    return this.logArchiveRetentionBothZeroError();
   });
 
   readonly strikeInactivityWindowHoursError = computed(() => {


### PR DESCRIPTION
Relates to #569

## Summary by Sourcery

Allow zero values for log configuration limits while enforcing sensible validation rules when archiving is enabled.

Bug Fixes:
- Fix log configuration inputs rejecting zero values despite UI hints indicating zero is a valid option.
- Prevent invalid configuration where both archive retained count and archive time limit are set to zero when archiving is enabled.

Enhancements:
- Align frontend numeric input constraints with updated log configuration semantics for rolling size, retained files, time limits, and archive settings.