### PR TITLE
Fix number input eager clamping on keystrokes

### DIFF
--- a/code/frontend/src/app/ui/number-input/number-input.component.html
+++ b/code/frontend/src/app/ui/number-input/number-input.component.html
@@ -27,7 +27,7 @@
     [step]="step()"
     [value]="value()"
     (input)="onInput($event)"
-    (blur)="blurred.emit($event)"
+    (blur)="onBlur($event)"
   />
   @if (suffix()) {
     <span class="number-suffix">{{ suffix() }}</span>

--- a/code/frontend/src/app/ui/number-input/number-input.component.ts
+++ b/code/frontend/src/app/ui/number-input/number-input.component.ts
@@ -43,11 +43,10 @@ export class NumberInputComponent {
       let clamped = current;
       const minVal = this.min();
       const maxVal = this.max();
-      if (minVal != null) clamped = Math.max(clamped, minVal);
-      if (maxVal != null) clamped = Math.min(clamped, maxVal);
+      if (minVal != null) { clamped = Math.max(clamped, minVal); }
+      if (maxVal != null) { clamped = Math.min(clamped, maxVal); }
       if (clamped !== current) {
         this.value.set(clamped);
-        (event.target as HTMLInputElement).value = String(clamped);
       }
     }
     this.blurred.emit(event);

--- a/code/frontend/src/app/ui/number-input/number-input.component.ts
+++ b/code/frontend/src/app/ui/number-input/number-input.component.ts
@@ -34,21 +34,23 @@ export class NumberInputComponent {
       this.value.set(null);
       return;
     }
+    this.value.set(Number(target.value));
+  }
 
-    let num = Number(target.value);
-    const minVal = this.min();
-    const maxVal = this.max();
-
-    if (minVal != null) {
-      num = Math.max(num, minVal);
+  onBlur(event: FocusEvent): void {
+    const current = this.value();
+    if (current != null) {
+      let clamped = current;
+      const minVal = this.min();
+      const maxVal = this.max();
+      if (minVal != null) clamped = Math.max(clamped, minVal);
+      if (maxVal != null) clamped = Math.min(clamped, maxVal);
+      if (clamped !== current) {
+        this.value.set(clamped);
+        (event.target as HTMLInputElement).value = String(clamped);
+      }
     }
-
-    if (maxVal != null) {
-      num = Math.min(num, maxVal);
-    }
-    
-    target.value = String(num);
-    this.value.set(num);
+    this.blurred.emit(event);
   }
 
   increment(): void {


### PR DESCRIPTION
## Description

Fixes eager min/max clamping in the `app-number-input` component that interrupted typing mid-keystroke. Previously, `onInput` called `Math.max`/`Math.min` on every keystroke, so typing `-1` would clamp to `0` after the `-`, and typing `1000` would clamp to the max after each digit.

The fix moves clamping to `onBlur`: the value is clamped and the DOM input synced only when the field loses focus, leaving the user free to type any intermediate value.

## Related Issue

Closes #581

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Typed `-1` into Max Ratio, Max Seed Time, and Max Inactive Days fields — no mid-keystroke jumps
- Typed `1000` into a field with `[max]="999"` — value clamped correctly on blur
- Typed and then cleared a field — no errors, value resets to null as before

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I have announced my intent to work on this and received approval (issue #581)
- [x] My code follows the project's code standards
- [x] I have tested my changes thoroughly
- [ ] I have updated relevant documentation