### PR TITLE
Fix Custom Format score syncer not being scheduled accordingly

### DIFF
--- a/code/backend/Cleanuparr.Api.Tests/Features/Seeker/SeekerConfigControllerTests.cs
+++ b/code/backend/Cleanuparr.Api.Tests/Features/Seeker/SeekerConfigControllerTests.cs
@@ -194,17 +194,16 @@ public class SeekerConfigControllerTests : IDisposable
         _dataContext.SeekerInstanceConfigs.Add(new SeekerInstanceConfig
         {
             ArrInstanceId = radarr.Id,
-            Enabled = true
+            Enabled = true,
+            UseCustomFormatScore = true
         });
+
+        // Syncer was running: both proactive and CF score were enabled
+        var config = await _dataContext.SeekerConfigs.FirstAsync();
+        config.ProactiveSearchEnabled = true;
         await _dataContext.SaveChangesAsync();
 
-        // First enable CF score on the instance
-        var instanceConfig = await _dataContext.SeekerInstanceConfigs
-            .FirstAsync(s => s.ArrInstanceId == radarr.Id);
-        instanceConfig.UseCustomFormatScore = true;
-        await _dataContext.SaveChangesAsync();
-
-        // Now disable it
+        // Disable CF score — syncer conditions no longer met
         var request = new UpdateSeekerConfigRequest
         {
             SearchEnabled = true,
@@ -223,25 +222,22 @@ public class SeekerConfigControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task UpdateSeekerConfig_WhenSearchReenabledWithCustomFormatActive_TriggersSyncerOnce()
+    public async Task UpdateSeekerConfig_WhenProactiveSearchDisabled_StopsSyncerJob()
     {
         var radarr = SeekerTestDataFactory.AddRadarrInstance(_dataContext);
         _dataContext.SeekerInstanceConfigs.Add(new SeekerInstanceConfig
         {
             ArrInstanceId = radarr.Id,
-            Enabled = true
+            Enabled = true,
+            UseCustomFormatScore = true
         });
-        await _dataContext.SaveChangesAsync();
 
-        // Set up state: CF score already enabled on instance, search currently disabled
-        var instanceConfig = await _dataContext.SeekerInstanceConfigs
-            .FirstAsync(s => s.ArrInstanceId == radarr.Id);
-        instanceConfig.UseCustomFormatScore = true;
+        // Syncer was running: both proactive and CF score were enabled
         var config = await _dataContext.SeekerConfigs.FirstAsync();
-        config.SearchEnabled = false;
+        config.ProactiveSearchEnabled = true;
         await _dataContext.SaveChangesAsync();
 
-        // Re-enable search
+        // Disable proactive search — syncer should stop even though CF score is still enabled
         var request = new UpdateSeekerConfigRequest
         {
             SearchEnabled = true,
@@ -256,6 +252,74 @@ public class SeekerConfigControllerTests : IDisposable
         await _controller.UpdateSeekerConfig(request);
 
         await _jobManagementService.Received(1)
+            .StopJob(JobType.CustomFormatScoreSyncer);
+    }
+
+    [Fact]
+    public async Task UpdateSeekerConfig_WhenProactiveSearchEnabled_WithCfScoreActive_StartsAndTriggersSyncer()
+    {
+        var radarr = SeekerTestDataFactory.AddRadarrInstance(_dataContext);
+        _dataContext.SeekerInstanceConfigs.Add(new SeekerInstanceConfig
+        {
+            ArrInstanceId = radarr.Id,
+            Enabled = true,
+            UseCustomFormatScore = true
+        });
+
+        // Syncer was NOT running: CF score enabled but proactive was off (default)
+        await _dataContext.SaveChangesAsync();
+
+        // Enable proactive search — syncer should start
+        var request = new UpdateSeekerConfigRequest
+        {
+            SearchEnabled = true,
+            SearchInterval = 3,
+            ProactiveSearchEnabled = true,
+            Instances =
+            [
+                new UpdateSeekerInstanceConfigRequest { ArrInstanceId = radarr.Id, Enabled = true, UseCustomFormatScore = true }
+            ]
+        };
+
+        await _controller.UpdateSeekerConfig(request);
+
+        await _jobManagementService.Received(1)
+            .StartJob(JobType.CustomFormatScoreSyncer, null, Arg.Any<string>());
+        await _jobManagementService.Received(1)
+            .TriggerJobOnce(JobType.CustomFormatScoreSyncer);
+    }
+
+    [Fact]
+    public async Task UpdateSeekerConfig_WhenCustomFormatScoreEnabledButProactiveDisabled_DoesNotStartSyncer()
+    {
+        var radarr = SeekerTestDataFactory.AddRadarrInstance(_dataContext);
+        _dataContext.SeekerInstanceConfigs.Add(new SeekerInstanceConfig
+        {
+            ArrInstanceId = radarr.Id,
+            Enabled = true,
+            UseCustomFormatScore = false
+        });
+
+        // ProactiveSearchEnabled stays false (default)
+        await _dataContext.SaveChangesAsync();
+
+        // Enable CF score but keep proactive disabled — syncer should NOT start
+        var request = new UpdateSeekerConfigRequest
+        {
+            SearchEnabled = true,
+            SearchInterval = 3,
+            ProactiveSearchEnabled = false,
+            Instances =
+            [
+                new UpdateSeekerInstanceConfigRequest { ArrInstanceId = radarr.Id, Enabled = true, UseCustomFormatScore = true }
+            ]
+        };
+
+        await _controller.UpdateSeekerConfig(request);
+
+        await _jobManagementService.DidNotReceive()
+            .StartJob(JobType.CustomFormatScoreSyncer, null, Arg.Any<string>());
+        await _jobManagementService.DidNotReceive()
             .TriggerJobOnce(JobType.CustomFormatScoreSyncer);
     }
 

--- a/code/backend/Cleanuparr.Api/Features/Seeker/Controllers/SeekerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/Seeker/Controllers/SeekerConfigController.cs
@@ -173,32 +173,22 @@ public sealed class SeekerConfigController : ControllerBase
                 await _jobManagementService.StartJob(JobType.Seeker, null, config.ToCronExpression());
             }
 
-            // Toggle CustomFormatScoreSyncer job when any instance's UseCustomFormatScore changes
-            if (anyUseCustomFormatScore != previousAnyUseCustomFormatScore)
+            // Start/stop CustomFormatScoreSyncer
+            bool syncerShouldBeRunning = anyUseCustomFormatScore && config.ProactiveSearchEnabled;
+            bool syncerWasRunning = previousAnyUseCustomFormatScore && previousProactiveSearchEnabled;
+
+            if (syncerShouldBeRunning != syncerWasRunning)
             {
-                if (anyUseCustomFormatScore)
+                if (syncerShouldBeRunning)
                 {
-                    _logger.LogInformation("UseCustomFormatScore enabled on an instance, starting CustomFormatScoreSyncer job");
+                    _logger.LogInformation("CustomFormatScoreSyncer conditions met, starting job");
                     await _jobManagementService.StartJob(JobType.CustomFormatScoreSyncer, null, Constants.CustomFormatScoreSyncerCron);
                     await _jobManagementService.TriggerJobOnce(JobType.CustomFormatScoreSyncer);
                 }
                 else
                 {
-                    _logger.LogInformation("UseCustomFormatScore disabled on all instances, stopping CustomFormatScoreSyncer job");
+                    _logger.LogInformation("CustomFormatScoreSyncer conditions no longer met, stopping job");
                     await _jobManagementService.StopJob(JobType.CustomFormatScoreSyncer);
-                }
-            }
-
-            // Trigger CustomFormatScoreSyncer once when search or proactive search is re-enabled with custom format scores active
-            if (previousAnyUseCustomFormatScore && anyUseCustomFormatScore)
-            {
-                bool searchJustEnabled = !previousSearchEnabled && config.SearchEnabled;
-                bool proactiveJustEnabled = !previousProactiveSearchEnabled && config.ProactiveSearchEnabled;
-
-                if (searchJustEnabled || proactiveJustEnabled)
-                {
-                    _logger.LogInformation("Search re-enabled with UseCustomFormatScore active, triggering CustomFormatScoreSyncer");
-                    await _jobManagementService.TriggerJobOnce(JobType.CustomFormatScoreSyncer);
                 }
             }
 

--- a/code/backend/Cleanuparr.Api/Jobs/BackgroundJobManager.cs
+++ b/code/backend/Cleanuparr.Api/Jobs/BackgroundJobManager.cs
@@ -105,6 +105,9 @@ public class BackgroundJobManager : IHostedService
         SeekerConfig seekerConfig = await dataContext.SeekerConfigs
             .AsNoTracking()
             .FirstAsync(cancellationToken);
+        bool anyUseCustomFormatScore = await dataContext.SeekerInstanceConfigs
+            .AsNoTracking()
+            .AnyAsync(s => s.Enabled && s.ArrInstance.Enabled && s.UseCustomFormatScore, cancellationToken);
 
         // Always register jobs, regardless of enabled status
         await RegisterQueueCleanerJob(queueCleanerConfig, cancellationToken);
@@ -112,7 +115,7 @@ public class BackgroundJobManager : IHostedService
         await RegisterDownloadCleanerJob(downloadCleanerConfig, cancellationToken);
         await RegisterBlacklistSyncJob(blacklistSyncConfig, cancellationToken);
         await RegisterSeekerJob(seekerConfig, cancellationToken);
-        await RegisterCustomFormatScoreSyncJob(dataContext, cancellationToken);
+        await RegisterCustomFormatScoreSyncJob(seekerConfig, anyUseCustomFormatScore, cancellationToken);
     }
     
     /// <summary>
@@ -195,14 +198,11 @@ public class BackgroundJobManager : IHostedService
     /// Registers the CustomFormatScoreSyncer job. Only adds triggers when at least one instance has UseCustomFormatScore enabled.
     /// Runs every 30 minutes to sync custom format scores from arr instances.
     /// </summary>
-    public async Task RegisterCustomFormatScoreSyncJob(DataContext dataContext, CancellationToken cancellationToken = default)
+    public async Task RegisterCustomFormatScoreSyncJob(SeekerConfig seekerConfig, bool anyUseCustomFormatScore, CancellationToken cancellationToken = default)
     {
         await AddJobWithoutTrigger<CustomFormatScoreSyncer>(cancellationToken);
 
-        bool anyUseCustomFormatScore = await dataContext.SeekerInstanceConfigs
-            .AnyAsync(s => s.Enabled && s.ArrInstance.Enabled && s.UseCustomFormatScore, cancellationToken);
-        
-        if (anyUseCustomFormatScore)
+        if (seekerConfig.ProactiveSearchEnabled && anyUseCustomFormatScore)
         {
             await AddTriggersForJob<CustomFormatScoreSyncer>(Constants.CustomFormatScoreSyncerCron, cancellationToken);
         }


### PR DESCRIPTION
## Summary by Sourcery

Align CustomFormatScoreSyncer scheduling with seeker configuration so it only runs when custom format scores are in use and proactive search is enabled.

Bug Fixes:
- Ensure CustomFormatScoreSyncer is started or stopped based on both custom format score usage and proactive search state, preventing it from running under incorrect conditions.

Enhancements:
- Simplify CustomFormatScoreSyncer trigger logic by centralizing its start/stop conditions and removing one-off trigger behavior tied to seeker search toggles.
- Derive CustomFormatScoreSyncer registration conditions at startup from seeker configuration and instance usage instead of querying within the registration method.