### PR TITLE
Remove CORS policy for production environments

### DIFF
--- a/code/backend/Cleanuparr.Api/DependencyInjection/ApiDI.cs
+++ b/code/backend/Cleanuparr.Api/DependencyInjection/ApiDI.cs
@@ -80,7 +80,10 @@ public static class ApiDI
         // Block non-auth requests until setup is complete
         app.UseMiddleware<SetupGuardMiddleware>();
 
-        app.UseCors("Any");
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseCors("DevSpa");
+        }
         app.UseRouting();
 
         app.UseAuthentication();

--- a/code/backend/Cleanuparr.Api/Program.cs
+++ b/code/backend/Cleanuparr.Api/Program.cs
@@ -80,19 +80,21 @@ builder.Services
     .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(ConfigurationPathProvider.GetConfigPath(), "DataProtection-Keys")))
     .SetApplicationName("Cleanuparr");
 
-// Add CORS before SignalR
-builder.Services.AddCors(options =>
+// CORS is needed only for development
+if (builder.Environment.IsDevelopment())
 {
-    options.AddPolicy("Any", policy =>
+    builder.Services.AddCors(options =>
     {
-        policy
-            // https://github.com/dotnet/aspnetcore/issues/4457#issuecomment-465669576
-            .SetIsOriginAllowed(_ => true)
-            .AllowAnyHeader()
-            .AllowAnyMethod()
-            .AllowCredentials(); // Required for SignalR auth
+        options.AddPolicy("DevSpa", policy =>
+        {
+            policy
+                .WithOrigins("http://localhost:4200", "http://127.0.0.1:4200")
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        });
     });
-});
+}
 
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {

--- a/e2e/tests/14-cors-wildcard-bug.spec.ts
+++ b/e2e/tests/14-cors-wildcard-bug.spec.ts
@@ -13,8 +13,7 @@ test.describe.serial('GHSA-rwpc-36mg-fpvf regression', () => {
     expect(res.status()).toBe(200);
 
     const acao = res.headers()['access-control-allow-origin'];
-    expect(acao).not.toBe(ATTACKER_ORIGIN);
-    expect(acao).not.toBe('*');
+    expect(acao).toBeUndefined();
   });
 
   test('does not reflect on CORS preflight either', async ({ request }) => {
@@ -27,7 +26,6 @@ test.describe.serial('GHSA-rwpc-36mg-fpvf regression', () => {
     });
 
     const acao = res.headers()['access-control-allow-origin'];
-    expect(acao).not.toBe(ATTACKER_ORIGIN);
-    expect(acao).not.toBe('*');
+    expect(acao).toBeUndefined();
   });
 });

--- a/e2e/tests/14-cors-wildcard-bug.spec.ts
+++ b/e2e/tests/14-cors-wildcard-bug.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { TEST_CONFIG } from './helpers/test-config';
+
+// Regression for GHSA-rwpc-36mg-fpvf
+
+test.describe.serial('GHSA-rwpc-36mg-fpvf regression', () => {
+  const ATTACKER_ORIGIN = 'https://attacker.example';
+
+  test('does not reflect a malicious Origin in Access-Control-Allow-Origin on actual requests', async ({ request }) => {
+    const res = await request.get(`${TEST_CONFIG.appUrl}/api/auth/status`, {
+      headers: { Origin: ATTACKER_ORIGIN },
+    });
+    expect(res.status()).toBe(200);
+
+    const acao = res.headers()['access-control-allow-origin'];
+    expect(acao).not.toBe(ATTACKER_ORIGIN);
+    expect(acao).not.toBe('*');
+  });
+
+  test('does not reflect on CORS preflight either', async ({ request }) => {
+    const res = await request.fetch(`${TEST_CONFIG.appUrl}/api/auth/status`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: ATTACKER_ORIGIN,
+        'Access-Control-Request-Method': 'GET',
+      },
+    });
+
+    const acao = res.headers()['access-control-allow-origin'];
+    expect(acao).not.toBe(ATTACKER_ORIGIN);
+    expect(acao).not.toBe('*');
+  });
+});


### PR DESCRIPTION
Relates to [GHSA-rwpc-36mg-fpvf](https://github.com/Cleanuparr/Cleanuparr/security/advisories/GHSA-rwpc-36mg-fpvf)

## Summary by Sourcery

Restrict CORS configuration to development and remove permissive wildcard policy from production.

Enhancements:
- Limit CORS to a named development SPA policy allowing only localhost Angular origins instead of a global wildcard policy.
- Guard CORS middleware usage so it is only applied in development environments.

Tests:
- Add an end-to-end test covering the previous wildcard CORS behaviour to prevent regressions related to the reported security advisory.