### PR TITLE
Fix Seeker failing in dry run mode

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure/Features/Arr/ArrClient.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Arr/ArrClient.cs
@@ -199,6 +199,12 @@ public abstract class ArrClient : IArrClient
     public virtual async Task<long> SearchItemAsync(ArrInstance arrInstance, SearchItem item)
     {
         List<long> ids = await SearchItemsAsync(arrInstance, [item]);
+
+        if (await _dryRunInterceptor.IsDryRunEnabled())
+        {
+            return ids.FirstOrDefault();
+        }
+
         return ids.First();
     }
 


### PR DESCRIPTION
Relates to #600

## Summary by Sourcery

Bug Fixes:
- Prevent Arr item search from failing by returning a default result when dry-run mode is enabled.