### PR TITLE
feat: Add MinSeeders guard to Download Cleaner seeding rules

### DIFF
--- a/code/backend/Cleanuparr.Api.Tests/Features/DownloadCleaner/SeedingRulesControllerTests.cs
+++ b/code/backend/Cleanuparr.Api.Tests/Features/DownloadCleaner/SeedingRulesControllerTests.cs
@@ -40,6 +40,7 @@ public class SeedingRulesControllerTests : IDisposable
         double maxRatio = 2.0,
         double minSeedTime = 0,
         double maxSeedTime = -1,
+        int minSeeders = -1,
         bool deleteSourceFiles = true)
     {
         return new SeedingRuleRequest
@@ -54,6 +55,7 @@ public class SeedingRulesControllerTests : IDisposable
             MaxRatio = maxRatio,
             MinSeedTime = minSeedTime,
             MaxSeedTime = maxSeedTime,
+            MinSeeders = minSeeders,
             DeleteSourceFiles = deleteSourceFiles,
         };
     }
@@ -133,6 +135,20 @@ public class SeedingRulesControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSeedingRules_ReturnsMinSeeders()
+    {
+        var client = SeedingRulesTestDataFactory.AddDownloadClient(_dataContext);
+        SeedingRulesTestDataFactory.AddQBitSeedingRule(_dataContext, client.Id, minSeeders: 5);
+
+        var result = await _controller.GetSeedingRules(client.Id);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var json = JsonSerializer.Serialize(okResult.Value);
+        var rule = JsonDocument.Parse(json).RootElement[0];
+        rule.GetProperty("minSeeders").GetInt32().ShouldBe(5);
+    }
+
+    [Fact]
     public async Task GetSeedingRules_DelugeClient_ReturnsEmptyTagFields()
     {
         var client = SeedingRulesTestDataFactory.AddDownloadClient(_dataContext, DownloadClientTypeName.Deluge, "Test Deluge");
@@ -177,6 +193,18 @@ public class SeedingRulesControllerTests : IDisposable
 
         var body = GetCreatedJsonBody(result);
         body.GetProperty("Priority").GetInt32().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CreateSeedingRule_SetsMinSeeders()
+    {
+        var client = SeedingRulesTestDataFactory.AddDownloadClient(_dataContext);
+        var request = CreateValidRequest(minSeeders: 5);
+
+        var result = await _controller.CreateSeedingRule(client.Id, request);
+
+        var body = GetCreatedJsonBody(result);
+        body.GetProperty("MinSeeders").GetInt32().ShouldBe(5);
     }
 
     [Fact]
@@ -304,6 +332,21 @@ public class SeedingRulesControllerTests : IDisposable
         var updated = okResult.Value.ShouldBeOfType<QBitSeedingRule>();
         updated.TagsAny.ShouldBe(new List<string> { "new-tag" });
         updated.TagsAll.ShouldBe(new List<string> { "must-have" });
+    }
+
+    [Fact]
+    public async Task UpdateSeedingRule_UpdatesMinSeeders()
+    {
+        var client = SeedingRulesTestDataFactory.AddDownloadClient(_dataContext);
+        var rule = SeedingRulesTestDataFactory.AddQBitSeedingRule(_dataContext, client.Id);
+
+        var request = CreateValidRequest(minSeeders: 5);
+
+        var result = await _controller.UpdateSeedingRule(rule.Id, request);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        var updated = okResult.Value.ShouldBeOfType<QBitSeedingRule>();
+        updated.MinSeeders.ShouldBe(5);
     }
 
     [Fact]

--- a/code/backend/Cleanuparr.Api.Tests/Features/DownloadCleaner/TestHelpers/SeedingRulesTestDataFactory.cs
+++ b/code/backend/Cleanuparr.Api.Tests/Features/DownloadCleaner/TestHelpers/SeedingRulesTestDataFactory.cs
@@ -119,7 +119,8 @@ public static class SeedingRulesTestDataFactory
         List<string>? tagsAll = null,
         double maxRatio = 2.0,
         double minSeedTime = 0,
-        double maxSeedTime = -1)
+        double maxSeedTime = -1,
+        int minSeeders = -1)
     {
         var rule = new QBitSeedingRule
         {
@@ -135,6 +136,7 @@ public static class SeedingRulesTestDataFactory
             MaxRatio = maxRatio,
             MinSeedTime = minSeedTime,
             MaxSeedTime = maxSeedTime,
+            MinSeeders = minSeeders,
             DeleteSourceFiles = true,
         };
 
@@ -150,7 +152,8 @@ public static class SeedingRulesTestDataFactory
         int priority = 1,
         List<string>? categories = null,
         double maxRatio = 2.0,
-        double maxSeedTime = -1)
+        double maxSeedTime = -1,
+        int minSeeders = -1)
     {
         var rule = new DelugeSeedingRule
         {
@@ -164,6 +167,7 @@ public static class SeedingRulesTestDataFactory
             MaxRatio = maxRatio,
             MinSeedTime = 0,
             MaxSeedTime = maxSeedTime,
+            MinSeeders = minSeeders,
             DeleteSourceFiles = true,
         };
 
@@ -179,7 +183,8 @@ public static class SeedingRulesTestDataFactory
         int priority = 1,
         List<string>? categories = null,
         double maxRatio = 2.0,
-        double maxSeedTime = -1)
+        double maxSeedTime = -1,
+        int minSeeders = -1)
     {
         var rule = new TransmissionSeedingRule
         {
@@ -195,6 +200,7 @@ public static class SeedingRulesTestDataFactory
             MaxRatio = maxRatio,
             MinSeedTime = 0,
             MaxSeedTime = maxSeedTime,
+            MinSeeders = minSeeders,
             DeleteSourceFiles = true,
         };
 

--- a/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Contracts/Requests/SeedingRuleRequest.cs
+++ b/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Contracts/Requests/SeedingRuleRequest.cs
@@ -59,6 +59,12 @@ public record SeedingRuleRequest
     public double MaxSeedTime { get; init; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download. Set to -1 to disable.
+    /// </summary>
+    [Range(-1, int.MaxValue, ErrorMessage = "Min seeders must be -1 or greater.")]
+    public int MinSeeders { get; init; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; init; } = true;

--- a/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/DownloadCleanerConfigController.cs
+++ b/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/DownloadCleanerConfigController.cs
@@ -81,6 +81,7 @@ public sealed class DownloadCleanerConfigController : ControllerBase
                         maxRatio = r.MaxRatio,
                         minSeedTime = r.MinSeedTime,
                         maxSeedTime = r.MaxSeedTime,
+                        minSeeders = r.MinSeeders,
                         deleteSourceFiles = r.DeleteSourceFiles,
                     }),
                     unlinkedConfig = unlinkedConfig is not null

--- a/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/SeedingRulesController.cs
+++ b/code/backend/Cleanuparr.Api/Features/DownloadCleaner/Controllers/SeedingRulesController.cs
@@ -57,6 +57,7 @@ public class SeedingRulesController : ControllerBase
                 maxRatio = r.MaxRatio,
                 minSeedTime = r.MinSeedTime,
                 maxSeedTime = r.MaxSeedTime,
+                minSeeders = r.MinSeeders,
                 deleteSourceFiles = r.DeleteSourceFiles,
             }));
         }
@@ -153,6 +154,7 @@ public class SeedingRulesController : ControllerBase
             existingRule.MaxRatio = ruleDto.MaxRatio;
             existingRule.MinSeedTime = ruleDto.MinSeedTime;
             existingRule.MaxSeedTime = ruleDto.MaxSeedTime;
+            existingRule.MinSeeders = ruleDto.MinSeeders;
             existingRule.DeleteSourceFiles = ruleDto.DeleteSourceFiles;
             // Priority is intentionally NOT updated here — use the reorder endpoint
 
@@ -304,6 +306,7 @@ public class SeedingRulesController : ControllerBase
                 MaxRatio = dto.MaxRatio,
                 MinSeedTime = dto.MinSeedTime,
                 MaxSeedTime = dto.MaxSeedTime,
+                MinSeeders = dto.MinSeeders,
                 DeleteSourceFiles = dto.DeleteSourceFiles,
             },
             DownloadClientTypeName.Deluge => new DelugeSeedingRule
@@ -317,6 +320,7 @@ public class SeedingRulesController : ControllerBase
                 MaxRatio = dto.MaxRatio,
                 MinSeedTime = dto.MinSeedTime,
                 MaxSeedTime = dto.MaxSeedTime,
+                MinSeeders = dto.MinSeeders,
                 DeleteSourceFiles = dto.DeleteSourceFiles,
             },
             DownloadClientTypeName.Transmission => new TransmissionSeedingRule
@@ -332,6 +336,7 @@ public class SeedingRulesController : ControllerBase
                 MaxRatio = dto.MaxRatio,
                 MinSeedTime = dto.MinSeedTime,
                 MaxSeedTime = dto.MaxSeedTime,
+                MinSeeders = dto.MinSeeders,
                 DeleteSourceFiles = dto.DeleteSourceFiles,
             },
             DownloadClientTypeName.uTorrent => new UTorrentSeedingRule
@@ -345,6 +350,7 @@ public class SeedingRulesController : ControllerBase
                 MaxRatio = dto.MaxRatio,
                 MinSeedTime = dto.MinSeedTime,
                 MaxSeedTime = dto.MaxSeedTime,
+                MinSeeders = dto.MinSeeders,
                 DeleteSourceFiles = dto.DeleteSourceFiles,
             },
             DownloadClientTypeName.rTorrent => new RTorrentSeedingRule
@@ -358,6 +364,7 @@ public class SeedingRulesController : ControllerBase
                 MaxRatio = dto.MaxRatio,
                 MinSeedTime = dto.MinSeedTime,
                 MaxSeedTime = dto.MaxSeedTime,
+                MinSeeders = dto.MinSeeders,
                 DeleteSourceFiles = dto.DeleteSourceFiles,
             },
             _ => throw new ArgumentOutOfRangeException(nameof(typeName), typeName, "Unsupported download client type")

--- a/code/backend/Cleanuparr.Domain/Entities/Deluge/Response/DownloadStatus.cs
+++ b/code/backend/Cleanuparr.Domain/Entities/Deluge/Response/DownloadStatus.cs
@@ -33,6 +33,9 @@ public sealed record DownloadStatus
     public long SeedingTime { get; init; }
     
     public float Ratio { get; init; }
+
+    [JsonProperty("total_seeds")]
+    public int TotalSeeds { get; init; }
     
     public required IReadOnlyList<Tracker> Trackers { get; init; }
     

--- a/code/backend/Cleanuparr.Domain/Entities/ITorrentItemWrapper.cs
+++ b/code/backend/Cleanuparr.Domain/Entities/ITorrentItemWrapper.cs
@@ -22,6 +22,11 @@ public interface ITorrentItemWrapper
     
     double Ratio { get; }
 
+    /// <summary>
+    /// Total seeders reported by the download client when available.
+    /// </summary>
+    int? SeederCount { get; }
+
     long Eta { get; }
     
     long SeedingTimeSeconds { get; }

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/DelugeItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/DelugeItemWrapperTests.cs
@@ -449,4 +449,23 @@ public class DelugeItemWrapperTests
         // Assert
         result.ShouldBe(expected);
     }
+
+    [Fact]
+    public void SeederCount_ReturnsTotalSeeds()
+    {
+        // Arrange
+        var downloadStatus = new DownloadStatus
+        {
+            TotalSeeds = 42,
+            Trackers = new List<Tracker>(),
+            DownloadLocation = "/test/path"
+        };
+        var wrapper = new DelugeItemWrapper(downloadStatus);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBe(42);
+    }
 }

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitItemWrapperTests.cs
@@ -221,6 +221,21 @@ public class QBitItemWrapperTests
     }
 
     [Fact]
+    public void SeederCount_ReturnsTotalSeeds()
+    {
+        // Arrange
+        var torrentInfo = new TorrentInfo { TotalSeeds = 5 };
+        var trackers = new List<TorrentTracker>();
+        var wrapper = new QBitItemWrapper(torrentInfo, trackers, false);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBe(5);
+    }
+
+    [Fact]
     public void Eta_ReturnsCorrectValue()
     {
         // Arrange

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceDCTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceDCTests.cs
@@ -331,6 +331,21 @@ public class QBitServiceDCTests : IClassFixture<QBitServiceFixture>
                 DeleteSourceFiles = false
             };
 
+        private static ITorrentItemWrapper CreateTorrentWithSeederCount(string hash, int? seederCount)
+        {
+            var torrent = Substitute.For<ITorrentItemWrapper>();
+            torrent.Hash.Returns(hash);
+            torrent.Name.Returns($"Test {hash}");
+            torrent.Category.Returns("movies");
+            torrent.IsPrivate.Returns(false);
+            torrent.Ratio.Returns(2.0);
+            torrent.SeedingTimeSeconds.Returns((long)TimeSpan.FromHours(10).TotalSeconds);
+            torrent.SeederCount.Returns(seederCount);
+            torrent.TrackerDomains.Returns(Array.Empty<string>());
+            torrent.Tags.Returns(Array.Empty<string>());
+            return torrent;
+        }
+
         private void SetupDeleteMock()
         {
             _fixture.ClientWrapper
@@ -378,6 +393,75 @@ public class QBitServiceDCTests : IClassFixture<QBitServiceFixture>
             // Assert
             await _fixture.ClientWrapper.Received(1)
                 .DeleteAsync(Arg.Is<IEnumerable<string>>(h => h.Contains("hash1")), false);
+        }
+
+        [Fact]
+        public async Task SkipsTorrent_WhenMinimumSeedersNotReached()
+        {
+            // Arrange
+            var sut = _fixture.CreateSut();
+            SetupDeleteMock();
+
+            var downloads = new List<ITorrentItemWrapper>
+            {
+                CreateTorrentWithSeederCount("hash1", 4)
+            };
+            var rule = CreateRule("movies", TorrentPrivacyType.Public);
+            rule.MinSeeders = 5;
+            var rules = new List<ISeedingRule> { rule };
+
+            // Act
+            await sut.CleanDownloadsAsync(downloads, rules);
+
+            // Assert
+            await _fixture.ClientWrapper.DidNotReceive()
+                .DeleteAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>());
+        }
+
+        [Fact]
+        public async Task CleansTorrent_WhenMinimumSeedersReached()
+        {
+            // Arrange
+            var sut = _fixture.CreateSut();
+            SetupDeleteMock();
+
+            var downloads = new List<ITorrentItemWrapper>
+            {
+                CreateTorrentWithSeederCount("hash1", 5)
+            };
+            var rule = CreateRule("movies", TorrentPrivacyType.Public);
+            rule.MinSeeders = 5;
+            var rules = new List<ISeedingRule> { rule };
+
+            // Act
+            await sut.CleanDownloadsAsync(downloads, rules);
+
+            // Assert
+            await _fixture.ClientWrapper.Received(1)
+                .DeleteAsync(Arg.Is<IEnumerable<string>>(h => h.Contains("hash1")), false);
+        }
+
+        [Fact]
+        public async Task SkipsTorrent_WhenMinimumSeedersConfiguredAndSeederCountUnavailable()
+        {
+            // Arrange
+            var sut = _fixture.CreateSut();
+            SetupDeleteMock();
+
+            var downloads = new List<ITorrentItemWrapper>
+            {
+                CreateTorrentWithSeederCount("hash1", null)
+            };
+            var rule = CreateRule("movies", TorrentPrivacyType.Public);
+            rule.MinSeeders = 5;
+            var rules = new List<ISeedingRule> { rule };
+
+            // Act
+            await sut.CleanDownloadsAsync(downloads, rules);
+
+            // Assert
+            await _fixture.ClientWrapper.DidNotReceive()
+                .DeleteAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<bool>());
         }
 
         [Fact]

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/RTorrentItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/RTorrentItemWrapperTests.cs
@@ -580,4 +580,18 @@ public class RTorrentItemWrapperTests
             result.ShouldBeFalse();
         }
     }
+
+    [Fact]
+    public void SeederCount_ReturnsNull()
+    {
+        // Arrange
+        var torrent = new RTorrentTorrent { Hash = "HASH1", Name = "Test" };
+        var wrapper = new RTorrentItemWrapper(torrent);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBeNull();
+    }
 }

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionItemWrapperTests.cs
@@ -205,6 +205,56 @@ public class TransmissionItemWrapperTests
         result.ShouldBe(expected);
     }
 
+    [Fact]
+    public void SeederCount_WithTrackerStats_ReturnsMaxSeederCount()
+    {
+        // Arrange
+        var torrentInfo = new TorrentInfo
+        {
+            TrackerStats = new TransmissionTorrentTrackerStats[]
+            {
+                new() { SeederCount = 3L },
+                new() { SeederCount = 7L },
+                new() { SeederCount = 5L },
+            }
+        };
+        var wrapper = new TransmissionItemWrapper(torrentInfo);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBe(7);
+    }
+
+    [Fact]
+    public void SeederCount_WithNullTrackerStats_ReturnsNull()
+    {
+        // Arrange
+        var torrentInfo = new TorrentInfo { TrackerStats = null };
+        var wrapper = new TransmissionItemWrapper(torrentInfo);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SeederCount_WithEmptyTrackerStats_ReturnsNull()
+    {
+        // Arrange
+        var torrentInfo = new TorrentInfo { TrackerStats = Array.Empty<TransmissionTorrentTrackerStats>() };
+        var wrapper = new TransmissionItemWrapper(torrentInfo);
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
     // TrackerDomains property tests
     [Fact]
     public void TrackerDomains_WithMultipleTrackers_ReturnsExtractedDomains()

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/TransmissionServiceTests.cs
@@ -45,6 +45,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -97,6 +98,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -156,6 +158,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -226,6 +229,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -283,6 +287,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -348,6 +353,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -401,6 +407,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -465,6 +472,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -531,6 +539,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -587,6 +596,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -650,6 +660,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS
@@ -709,6 +720,7 @@ public class TransmissionServiceTests : IClassFixture<TransmissionServiceFixture
                 TorrentFields.SECONDS_SEEDING,
                 TorrentFields.UPLOAD_RATIO,
                 TorrentFields.TRACKERS,
+                TorrentFields.TRACKER_STATS,
                 TorrentFields.RATE_DOWNLOAD,
                 TorrentFields.TOTAL_SIZE,
                 TorrentFields.LABELS

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentItemWrapperTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentItemWrapperTests.cs
@@ -278,4 +278,18 @@ public class UTorrentItemWrapperTests
         // Assert
         result.ShouldBeFalse();
     }
+
+    [Fact]
+    public void SeederCount_ReturnsSeedsInSwarm()
+    {
+        // Arrange
+        var torrentItem = new UTorrentItem { SeedsInSwarm = 15 };
+        var wrapper = new UTorrentItemWrapper(torrentItem, new UTorrentProperties());
+
+        // Act
+        var result = wrapper.SeederCount;
+
+        // Assert
+        result.ShouldBe(15);
+    }
 }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Deluge/DelugeClient.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Deluge/DelugeClient.cs
@@ -25,6 +25,7 @@ public sealed class DelugeClient
         "label",
         "seeding_time",
         "ratio",
+        "total_seeds",
         "trackers",
         "download_payload_rate",
         "total_size",

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Deluge/DelugeItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Deluge/DelugeItemWrapper.cs
@@ -43,6 +43,8 @@ public sealed class DelugeItemWrapper : ITorrentItemWrapper
     
     public double Ratio => Info.Ratio;
 
+    public int? SeederCount => Info.TotalSeeds;
+
     public long Eta => (long)Info.Eta;
     
     public long SeedingTimeSeconds => Info.SeedingTime;

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/DownloadService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/DownloadService.cs
@@ -110,7 +110,7 @@ public abstract class DownloadService : IDownloadService
             SetDownloadClientContext();
 
             TimeSpan seedingTime = TimeSpan.FromSeconds(torrent.SeedingTimeSeconds);
-            SeedingCheckResult result = ShouldCleanDownload(torrent.Ratio, seedingTime, seedingRule);
+            SeedingCheckResult result = ShouldCleanDownload(torrent.Ratio, seedingTime, torrent.SeederCount, seedingRule);
 
             if (!result.ShouldClean)
             {
@@ -149,8 +149,13 @@ public abstract class DownloadService : IDownloadService
     /// <param name="deleteSourceFiles">Whether to delete the source files along with the torrent</param>
     public abstract Task DeleteDownload(ITorrentItemWrapper torrent, bool deleteSourceFiles);
     
-    protected SeedingCheckResult ShouldCleanDownload(double ratio, TimeSpan seedingTime, ISeedingRule category)
+    protected SeedingCheckResult ShouldCleanDownload(double ratio, TimeSpan seedingTime, int? seederCount, ISeedingRule category)
     {
+        if (BelowMinimumSeeders(seederCount, category))
+        {
+            return new();
+        }
+
         // check ratio
         if (DownloadReachedRatio(ratio, seedingTime, category))
         {
@@ -218,6 +223,34 @@ public abstract class DownloadService : IDownloadService
         
         // max ratio is 0 or reached
         return true;
+    }
+
+    private bool BelowMinimumSeeders(int? seederCount, ISeedingRule category)
+    {
+        if (category.MinSeeders <= 0)
+        {
+            return false;
+        }
+
+        string downloadName = ContextProvider.Get<string>(ContextProvider.Keys.ItemName);
+
+        if (!seederCount.HasValue)
+        {
+            _logger.LogDebug("skip | download seeder count is unavailable | {name}", downloadName);
+            return true;
+        }
+
+        if (seederCount.Value < category.MinSeeders)
+        {
+            _logger.LogDebug(
+                "skip | download has fewer seeders than minimum | {seeders}/{minSeeders} | {name}",
+                seederCount.Value,
+                category.MinSeeders,
+                downloadName);
+            return true;
+        }
+
+        return false;
     }
     
     private bool DownloadReachedMaxSeedTime(TimeSpan seedingTime, ISeedingRule category)

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitItemWrapper.cs
@@ -45,6 +45,8 @@ public sealed class QBitItemWrapper : ITorrentItemWrapper
     
     public double Ratio => Info.Ratio;
 
+    public int? SeederCount => Info.TotalSeeds;
+
     public long Eta => Info.EstimatedTime?.TotalSeconds is { } eta ? (long)eta : 0;
     
     public long SeedingTimeSeconds => Info.SeedingTime?.TotalSeconds is { } seedTime ? (long)seedTime : 0;

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RTorrent/RTorrentItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/RTorrent/RTorrentItemWrapper.cs
@@ -48,6 +48,8 @@ public sealed class RTorrentItemWrapper : ITorrentItemWrapper
     /// </summary>
     public double Ratio => Info.Ratio / 1000.0;
 
+    public int? SeederCount => null;
+
     public long Eta => CalculateEta();
 
     public long SeedingTimeSeconds => CalculateSeedingTime();

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionItemWrapper.cs
@@ -43,6 +43,10 @@ public sealed class TransmissionItemWrapper : ITorrentItemWrapper
     
     public double Ratio => Info.uploadRatio ?? 0.0;
 
+    public int? SeederCount => Info.TrackerStats is { Length: > 0 } trackerStats
+        ? (int?)trackerStats.Max(t => t.SeederCount)
+        : null;
+
     public long Eta => Info.Eta ?? 0;
     
     public long SeedingTimeSeconds => Info.SecondsSeeding ?? 0;

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/Transmission/TransmissionService.cs
@@ -33,6 +33,7 @@ public partial class TransmissionService : DownloadService, ITransmissionService
         TorrentFields.DOWNLOADED_EVER,
         TorrentFields.DOWNLOAD_DIR,
         TorrentFields.SECONDS_SEEDING,
+        TorrentFields.TRACKER_STATS,
         TorrentFields.UPLOAD_RATIO,
         TorrentFields.TRACKERS,
         TorrentFields.RATE_DOWNLOAD,

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentItemWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentItemWrapper.cs
@@ -44,6 +44,8 @@ public sealed class UTorrentItemWrapper : ITorrentItemWrapper
     
     public double Ratio => Info.Ratio;
 
+    public int? SeederCount => Info.SeedsInSwarm;
+
     public long Eta => Info.ETA;
     
     public long SeedingTimeSeconds => (long?)Info.SeedingTime?.TotalSeconds ?? 0;

--- a/code/backend/Cleanuparr.Persistence.Tests/Models/Configuration/DownloadCleaner/SeedingRuleTests.cs
+++ b/code/backend/Cleanuparr.Persistence.Tests/Models/Configuration/DownloadCleaner/SeedingRuleTests.cs
@@ -25,6 +25,21 @@ public sealed class QBitSeedingRuleTests
         rule.PrivacyType.ShouldBe(TorrentPrivacyType.Public);
     }
 
+    [Fact]
+    public void MinSeeders_DefaultsToDisabled()
+    {
+        var rule = new QBitSeedingRule
+        {
+            Name = "test",
+            MaxRatio = -1,
+            MinSeedTime = 0,
+            MaxSeedTime = 24,
+            DeleteSourceFiles = false
+        };
+
+        rule.MinSeeders.ShouldBe(-1);
+    }
+
     #endregion
 
     #region Validate - Valid Configurations
@@ -294,6 +309,48 @@ public sealed class QBitSeedingRuleTests
         };
 
         Should.NotThrow(() => config.Validate());
+    }
+
+    #endregion
+
+    #region Validate - MinSeeders Validation
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(5)]
+    public void Validate_WithValidMinSeeders_DoesNotThrow(int minSeeders)
+    {
+        var config = new QBitSeedingRule
+        {
+            Name = "test-category",
+            Categories = ["test-category"],
+            MaxRatio = 2.0,
+            MinSeedTime = 0,
+            MaxSeedTime = -1,
+            MinSeeders = minSeeders,
+            DeleteSourceFiles = true
+        };
+
+        Should.NotThrow(() => config.Validate());
+    }
+
+    [Fact]
+    public void Validate_WithMinSeedersLessThanDisabled_ThrowsValidationException()
+    {
+        var config = new QBitSeedingRule
+        {
+            Name = "test-category",
+            Categories = ["test-category"],
+            MaxRatio = 2.0,
+            MinSeedTime = 0,
+            MaxSeedTime = -1,
+            MinSeeders = -2,
+            DeleteSourceFiles = true
+        };
+
+        var exception = Should.Throw<ValidationException>(() => config.Validate());
+        exception.Message.ShouldBe("Min seeders can not be less than -1");
     }
 
     #endregion

--- a/code/backend/Cleanuparr.Persistence/Migrations/Data/20260521150000_AddMinSeedersToSeedingRules.cs
+++ b/code/backend/Cleanuparr.Persistence/Migrations/Data/20260521150000_AddMinSeedersToSeedingRules.cs
@@ -1,0 +1,53 @@
+using Cleanuparr.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Cleanuparr.Persistence.Migrations.Data
+{
+    /// <inheritdoc />
+    [DbContext(typeof(DataContext))]
+    [Migration("20260521150000_AddMinSeedersToSeedingRules")]
+    public partial class AddMinSeedersToSeedingRules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            foreach (var table in new[]
+                     {
+                         "q_bit_seeding_rules",
+                         "deluge_seeding_rules",
+                         "transmission_seeding_rules",
+                         "u_torrent_seeding_rules",
+                         "r_torrent_seeding_rules"
+                     })
+            {
+                migrationBuilder.AddColumn<int>(
+                    name: "min_seeders",
+                    table: table,
+                    type: "INTEGER",
+                    nullable: false,
+                    defaultValue: -1);
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            foreach (var table in new[]
+                     {
+                         "q_bit_seeding_rules",
+                         "deluge_seeding_rules",
+                         "transmission_seeding_rules",
+                         "u_torrent_seeding_rules",
+                         "r_torrent_seeding_rules"
+                     })
+            {
+                migrationBuilder.DropColumn(
+                    name: "min_seeders",
+                    table: table);
+            }
+        }
+    }
+}

--- a/code/backend/Cleanuparr.Persistence/Migrations/Data/DataContextModelSnapshot.cs
+++ b/code/backend/Cleanuparr.Persistence/Migrations/Data/DataContextModelSnapshot.cs
@@ -145,6 +145,10 @@ namespace Cleanuparr.Persistence.Migrations.Data
                         .HasColumnType("REAL")
                         .HasColumnName("min_seed_time");
 
+                    b.Property<int>("MinSeeders")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("min_seeders");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -236,6 +240,10 @@ namespace Cleanuparr.Persistence.Migrations.Data
                         .HasColumnType("REAL")
                         .HasColumnName("min_seed_time");
 
+                    b.Property<int>("MinSeeders")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("min_seeders");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -306,6 +314,10 @@ namespace Cleanuparr.Persistence.Migrations.Data
                         .HasColumnType("REAL")
                         .HasColumnName("min_seed_time");
 
+                    b.Property<int>("MinSeeders")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("min_seeders");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasColumnType("TEXT")
@@ -365,6 +377,10 @@ namespace Cleanuparr.Persistence.Migrations.Data
                     b.Property<double>("MinSeedTime")
                         .HasColumnType("REAL")
                         .HasColumnName("min_seed_time");
+
+                    b.Property<int>("MinSeeders")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("min_seeders");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -435,6 +451,10 @@ namespace Cleanuparr.Persistence.Migrations.Data
                     b.Property<double>("MinSeedTime")
                         .HasColumnType("REAL")
                         .HasColumnName("min_seed_time");
+
+                    b.Property<int>("MinSeeders")
+                        .HasColumnType("INTEGER")
+                        .HasColumnName("min_seeders");
 
                     b.Property<string>("Name")
                         .IsRequired()

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/DelugeSeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/DelugeSeedingRule.cs
@@ -44,6 +44,11 @@ public sealed record DelugeSeedingRule : ISeedingRule
     public double MaxSeedTime { get; set; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download.
+    /// </summary>
+    public int MinSeeders { get; set; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; set; }
@@ -68,6 +73,11 @@ public sealed record DelugeSeedingRule : ISeedingRule
         if (MinSeedTime < 0)
         {
             throw new ValidationException("Min seed time can not be negative");
+        }
+
+        if (MinSeeders < -1)
+        {
+            throw new ValidationException("Min seeders can not be less than -1");
         }
     }
 }

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/ISeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/ISeedingRule.cs
@@ -39,5 +39,10 @@ public interface ISeedingRule : IConfig
 
     double MaxSeedTime { get; set; }
 
+    /// <summary>
+    /// Minimum number of seeders required before cleanup. Negative values disable the check.
+    /// </summary>
+    int MinSeeders { get; set; }
+
     bool DeleteSourceFiles { get; set; }
 }

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/QBitSeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/QBitSeedingRule.cs
@@ -48,6 +48,11 @@ public sealed record QBitSeedingRule : ISeedingRule, ITagFilterable
     public double MaxSeedTime { get; set; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download.
+    /// </summary>
+    public int MinSeeders { get; set; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; set; }
@@ -72,6 +77,11 @@ public sealed record QBitSeedingRule : ISeedingRule, ITagFilterable
         if (MinSeedTime < 0)
         {
             throw new ValidationException("Min seed time can not be negative");
+        }
+
+        if (MinSeeders < -1)
+        {
+            throw new ValidationException("Min seeders can not be less than -1");
         }
     }
 }

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/RTorrentSeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/RTorrentSeedingRule.cs
@@ -44,6 +44,11 @@ public sealed record RTorrentSeedingRule : ISeedingRule
     public double MaxSeedTime { get; set; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download.
+    /// </summary>
+    public int MinSeeders { get; set; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; set; }
@@ -68,6 +73,11 @@ public sealed record RTorrentSeedingRule : ISeedingRule
         if (MinSeedTime < 0)
         {
             throw new ValidationException("Min seed time can not be negative");
+        }
+
+        if (MinSeeders < -1)
+        {
+            throw new ValidationException("Min seeders can not be less than -1");
         }
     }
 }

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/TransmissionSeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/TransmissionSeedingRule.cs
@@ -54,6 +54,11 @@ public sealed record TransmissionSeedingRule : ISeedingRule, ITagFilterable
     public double MaxSeedTime { get; set; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download.
+    /// </summary>
+    public int MinSeeders { get; set; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; set; }
@@ -78,6 +83,11 @@ public sealed record TransmissionSeedingRule : ISeedingRule, ITagFilterable
         if (MinSeedTime < 0)
         {
             throw new ValidationException("Min seed time can not be negative");
+        }
+
+        if (MinSeeders < -1)
+        {
+            throw new ValidationException("Min seeders can not be less than -1");
         }
     }
 }

--- a/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/UTorrentSeedingRule.cs
+++ b/code/backend/Cleanuparr.Persistence/Models/Configuration/DownloadCleaner/UTorrentSeedingRule.cs
@@ -44,6 +44,11 @@ public sealed record UTorrentSeedingRule : ISeedingRule
     public double MaxSeedTime { get; set; } = -1;
 
     /// <summary>
+    /// Minimum number of seeders required before removing a download.
+    /// </summary>
+    public int MinSeeders { get; set; } = -1;
+
+    /// <summary>
     /// Whether to delete the source files when cleaning the download.
     /// </summary>
     public bool DeleteSourceFiles { get; set; }
@@ -68,6 +73,11 @@ public sealed record UTorrentSeedingRule : ISeedingRule
         if (MinSeedTime < 0)
         {
             throw new ValidationException("Min seed time can not be negative");
+        }
+
+        if (MinSeeders < -1)
+        {
+            throw new ValidationException("Min seeders can not be less than -1");
         }
     }
 }

--- a/code/frontend/src/app/core/services/documentation.service.ts
+++ b/code/frontend/src/app/core/services/documentation.service.ts
@@ -81,6 +81,7 @@ export class DocumentationService {
       'maxRatio': 'max-ratio',
       'minSeedTime': 'min-seed-time',
       'maxSeedTime': 'max-seed-time',
+      'minSeeders': 'min-seeders',
       'deleteSourceFiles': 'delete-source-files',
       'unlinkedEnabled': 'enable-unlinked-download-handling',
       'unlinkedTargetCategory': 'target-category',

--- a/code/frontend/src/app/features/settings/download-cleaner/download-cleaner.component.html
+++ b/code/frontend/src/app/features/settings/download-cleaner/download-cleaner.component.html
@@ -140,6 +140,9 @@
                         @if (rule.minSeedTime > 0) {
                           <app-badge>Min Seed: {{ rule.minSeedTime }}h</app-badge>
                         }
+                        @if ((rule.minSeeders ?? -1) > 0) {
+                          <app-badge>Min Seeders: {{ rule.minSeeders }}</app-badge>
+                        }
                         @if (rule.trackerPatterns.length) {
                           <app-badge severity="warning">{{ rule.trackerPatterns.length }} tracker pattern{{ rule.trackerPatterns.length !== 1 ? 's' : '' }}</app-badge>
                         }
@@ -262,6 +265,9 @@
     <app-number-input label="Max Seed Time" [(value)]="ruleMaxSeedTime" suffix="hours" [min]="-1"
       hint="Maximum time to seed before removing (-1 means disabled)"
       helpKey="download-cleaner:maxSeedTime" />
+    <app-number-input label="Min Seeders" [(value)]="ruleMinSeeders" [min]="-1" [step]="1"
+      hint="Minimum swarm seeders required before removing (-1 means disabled; unavailable counts keep the download)"
+      helpKey="download-cleaner:minSeeders" />
     @if (ruleDisabledError()) {
       <div class="category-error">{{ ruleDisabledError() }}</div>
     }

--- a/code/frontend/src/app/features/settings/download-cleaner/download-cleaner.component.ts
+++ b/code/frontend/src/app/features/settings/download-cleaner/download-cleaner.component.ts
@@ -128,6 +128,7 @@ export class DownloadCleanerComponent implements OnInit, HasPendingChanges {
   readonly ruleMaxRatio = signal<number | null>(-1);
   readonly ruleMinSeedTime = signal<number | null>(0);
   readonly ruleMaxSeedTime = signal<number | null>(-1);
+  readonly ruleMinSeeders = signal<number | null>(-1);
   readonly ruleDeleteSourceFiles = signal(true);
 
   readonly scheduleIntervalOptions = computed(() => {
@@ -267,6 +268,7 @@ export class DownloadCleanerComponent implements OnInit, HasPendingChanges {
       this.ruleMaxRatio.set(rule.maxRatio);
       this.ruleMinSeedTime.set(rule.minSeedTime);
       this.ruleMaxSeedTime.set(rule.maxSeedTime);
+      this.ruleMinSeeders.set(rule.minSeeders ?? -1);
       this.ruleDeleteSourceFiles.set(rule.deleteSourceFiles);
     } else {
       this.ruleName.set('');
@@ -278,6 +280,7 @@ export class DownloadCleanerComponent implements OnInit, HasPendingChanges {
       this.ruleMaxRatio.set(-1);
       this.ruleMinSeedTime.set(0);
       this.ruleMaxSeedTime.set(-1);
+      this.ruleMinSeeders.set(-1);
       this.ruleDeleteSourceFiles.set(true);
     }
     this.ruleModalVisible.set(true);
@@ -300,6 +303,7 @@ export class DownloadCleanerComponent implements OnInit, HasPendingChanges {
       maxRatio: this.ruleMaxRatio() ?? -1,
       minSeedTime: this.ruleMinSeedTime() ?? 0,
       maxSeedTime: this.ruleMaxSeedTime() ?? -1,
+      minSeeders: this.ruleMinSeeders() ?? -1,
       deleteSourceFiles: this.ruleDeleteSourceFiles(),
     };
 

--- a/code/frontend/src/app/shared/models/download-cleaner-config.model.ts
+++ b/code/frontend/src/app/shared/models/download-cleaner-config.model.ts
@@ -12,6 +12,7 @@ export interface SeedingRule {
   maxRatio: number;
   minSeedTime: number;
   maxSeedTime: number;
+  minSeeders?: number;
   deleteSourceFiles: boolean;
 }
 
@@ -54,6 +55,7 @@ export function createDefaultSeedingRule(): SeedingRule {
     maxRatio: -1,
     minSeedTime: 0,
     maxSeedTime: -1,
+    minSeeders: -1,
     deleteSourceFiles: true,
   };
 }

--- a/docs/docs/configuration/download-cleaner/index.mdx
+++ b/docs/docs/configuration/download-cleaner/index.mdx
@@ -90,7 +90,7 @@ mytracker.com
 </p>
 
 <Note>
-A download is cleaned when both `Max Ratio` and `Min Seed Time` are reached, OR when `Max Seed Time` is reached regardless of ratio.
+A download is cleaned when both `Max Ratio` and `Min Seed Time` are reached, OR when `Max Seed Time` is reached regardless of ratio. If `Min Seeders` is configured, the download is kept until that minimum seeder count is also met.
 </Note>
 
 <Important>
@@ -193,6 +193,18 @@ Minimum time in hours to seed before removing a download that has reached the ma
 >
 
 Maximum time in hours to seed before removing a download regardless of ratio. Set to `-1` to disable time-based cleanup.
+
+</ConfigSection>
+
+<ConfigSection
+  title="Min Seeders"
+>
+
+Minimum number of seeders required before removing a download. Set to `-1` to disable seeder-count protection.
+
+When enabled, this acts as a deletion guard: downloads that have reached their ratio or seed-time cleanup condition are still kept if the reported seeder count is below this value.
+
+If the selected download client cannot report a seeder count for a download, Cleanuparr keeps the download instead of deleting it.
 
 </ConfigSection>
 

--- a/e2e/tests/12-seeding-rules-api.spec.ts
+++ b/e2e/tests/12-seeding-rules-api.spec.ts
@@ -55,6 +55,7 @@ test.describe.serial('Seeding Rules API', () => {
       maxRatio: 2.0,
       minSeedTime: 0,
       maxSeedTime: -1,
+      minSeeders: 5,
       deleteSourceFiles: true,
     });
     expect(res.status).toBe(201);
@@ -106,6 +107,7 @@ test.describe.serial('Seeding Rules API', () => {
     expect(moviesRule).toBeDefined();
     expect(moviesRule.categories).toEqual(['movies', 'films']);
     expect(moviesRule.trackerPatterns).toEqual(['tracker.example.com']);
+    expect(moviesRule.minSeeders).toBe(5);
     expect(moviesRule.priority).toBe(1);
   });
 
@@ -172,6 +174,7 @@ test.describe.serial('Seeding Rules API', () => {
       maxRatio: rule.maxRatio,
       minSeedTime: rule.minSeedTime,
       maxSeedTime: rule.maxSeedTime,
+      minSeeders: rule.minSeeders,
       deleteSourceFiles: rule.deleteSourceFiles,
     });
     expect(updateRes.status).toBe(200);
@@ -194,6 +197,7 @@ test.describe.serial('Seeding Rules API', () => {
       maxRatio: rule.maxRatio,
       minSeedTime: rule.minSeedTime,
       maxSeedTime: rule.maxSeedTime,
+      minSeeders: rule.minSeeders,
       deleteSourceFiles: rule.deleteSourceFiles,
     });
     expect(updateRes.status).toBe(200);


### PR DESCRIPTION
## Description

Closes #613.

Adds a configurable **MinSeeders** field to each seeding rule. When set to a positive value, the Download Cleaner will skip deletion if the swarm seeder count is below the threshold. Setting it to `-1` (default) disables the guard entirely.

## How it works

- `BelowMinimumSeeders()` is the **first guard** in `ShouldCleanDownload()`, evaluated before ratio and seed time
- If `MinSeeders <= 0` → guard disabled, proceed normally
- If seeder count is unavailable (rTorrent) → torrent is **kept** (safe default)
- If `seederCount < MinSeeders` → torrent is **kept**

## Seeder count per client

| Client | Source |
|---|---|
| qBittorrent | `TotalSeeds` |
| Deluge | `total_seeds` |
| Transmission | `Max(TrackerStats[].SeederCount)` |
| uTorrent | `SeedsInSwarm` (index 15) |
| rTorrent | `null` (API doesn't expose swarm seeder count) |

## Changes

- `ISeedingRule`: new `MinSeeders` property (default `-1`)
- All 5 seeding rule models: `MinSeeders` with validation (`>= -1`)
- `ITorrentItemWrapper`: new `SeederCount` (`int?`) property
- All 5 item wrappers: `SeederCount` implemented per-client
- `DownloadService`: `BelowMinimumSeeders()` guard added
- Transmission: `TRACKER_STATS` field added to torrent fetch
- Deluge: `total_seeds` field added to `DownloadStatus`
- EF Core migration `20260521150000_AddMinSeedersToSeedingRules`: `min_seeders INTEGER DEFAULT -1` on all 5 seeding rule tables
- API: `SeedingRulesController` and `DownloadCleanerConfigController` expose `minSeeders`
- Frontend: `Min Seeders` number input added to seeding rule form with badge display
- Docs: `Min Seeders` ConfigSection added
- E2E: `minSeeders` added to seeding rule API test payloads
- Unit tests: SeederCount and BelowMinimumSeeders logic covered for all 5 clients

## Test plan

Tested live against all 5 clients:

- [x] qBittorrent — minSeeders=1000 → kept; minSeeders=-1 → deleted
- [x] Transmission — minSeeders=1000 → kept; minSeeders=-1 → deleted
- [x] Deluge — minSeeders=1000 → kept; minSeeders=-1 → deleted
- [x] rTorrent — minSeeders=1000 → kept (SeederCount=null triggers safe default); minSeeders=-1 → deleted
- [x] uTorrent — minSeeders=1000 → kept; minSeeders=-1 → deleted