### PR TITLE
Add reason details to strike and queue-item-deleted notifications

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure/Features/Notifications/NotificationPublisher.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Notifications/NotificationPublisher.cs
@@ -172,6 +172,12 @@ public class NotificationPublisher : INotificationPublisher
             context.Data.Add("Rule name", rule.Name);
         }
 
+        var reasonDetails = FormatReasonDetails(record.StatusMessages);
+        if (!string.IsNullOrEmpty(reasonDetails))
+        {
+            context.Data.Add("Reason details", reasonDetails);
+        }
+
         return context;
     }
 
@@ -183,7 +189,7 @@ public class NotificationPublisher : INotificationPublisher
         var instanceUrl = ContextProvider.Get<Uri>(ContextProvider.Keys.ArrInstanceUrl);
         var imageUrl = GetImageFromContext(record, instanceType, instanceVersion);
 
-        return new NotificationContext
+        var context = new NotificationContext
         {
             EventType = NotificationEventType.QueueItemDeleted,
             Title = $"Deleting item from queue with reason: {reason}",
@@ -199,6 +205,57 @@ public class NotificationPublisher : INotificationPublisher
                 ["Url"] = instanceUrl.ToString(),
             }
         };
+
+        var reasonDetails = FormatReasonDetails(record.StatusMessages);
+        if (!string.IsNullOrEmpty(reasonDetails))
+        {
+            context.Data.Add("Reason details", reasonDetails);
+        }
+
+        return context;
+    }
+
+    /// <summary>
+    /// Formats the *arr StatusMessages into a short, human-readable string suitable for inclusion in a
+    /// notification. Takes the first message line from each of up to two status entries, joins them with
+    /// "; ", and truncates the result to roughly 300 characters so notification providers with size
+    /// limits (Telegram, Discord, etc.) don't reject the payload. Returns null when there is nothing
+    /// useful to surface.
+    /// </summary>
+    private static string? FormatReasonDetails(List<TrackedDownloadStatusMessage>? statusMessages)
+    {
+        if (statusMessages is null || statusMessages.Count == 0)
+        {
+            return null;
+        }
+
+        const int maxLength = 300;
+        const int maxEntries = 2;
+
+        var parts = new List<string>(maxEntries);
+        foreach (var entry in statusMessages.Take(maxEntries))
+        {
+            var text = entry?.Messages?.FirstOrDefault(static m => !string.IsNullOrWhiteSpace(m))
+                       ?? entry?.Title;
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                parts.Add(text.Trim());
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return null;
+        }
+
+        var joined = string.Join("; ", parts);
+        if (joined.Length > maxLength)
+        {
+            joined = joined.Substring(0, maxLength - 3) + "...";
+        }
+
+        return joined;
     }
 
     private static NotificationContext BuildDownloadCleanedContext(double ratio, TimeSpan seedingTime, string categoryName, CleanReason reason)


### PR DESCRIPTION
## Motivation

When `FailedImport` strikes (and other strikes that surface a `QueueRecord` with `StatusMessages`) fire, the existing notification body says something like:

> Strike received with reason: FailedImport

…with no indication of *why* the import failed. Operators currently have to SSH into the container and read the logs to see the actual *arr message (e.g. "Series title mismatch; automatic import is not possible", "No files found are eligible for import in /downloads/...", etc.). The same is true for queue-item-deleted notifications when the source record carries status messages.

The information is already on the `QueueRecord` (`StatusMessages`) — it is just not propagated into the notification's `Data` dictionary. This PR closes that gap.

## What changed

`code/backend/Cleanuparr.Infrastructure/Features/Notifications/NotificationPublisher.cs`:

- Both `BuildStrikeNotificationContext` and `BuildQueueItemDeletedContext` now conditionally append a `"Reason details"` entry to the notification's `Data` dictionary when `QueueRecord.StatusMessages` has something useful in it.
- The value is built by a new private helper `FormatReasonDetails(...)`:
  - Takes up to the first 2 status entries.
  - For each entry, prefers the first non-empty string in `Messages`; falls back to the entry's `Title` if `Messages` is null/empty.
  - Joins parts with `; ` and truncates the result to ~300 chars (with `...`) so size-limited providers (Telegram, Discord, etc.) don't reject the payload.
  - Returns `null` if there is nothing to surface; the caller skips the dictionary insert in that case.

The helper is defensive against null `statusMessages`, null entries, null `Messages` lists, and empty/whitespace strings — it will never throw on a malformed record.

## Backward compatibility

- No schema change. `Data` is `Dictionary<string, string>`; this just adds an optional extra key when the underlying record happens to carry status messages.
- All existing keys and their values are unchanged.
- Notification providers that iterate `context.Data` as a generic key/value map (the templates in `Apprise`, `Discord`, `Gotify`, `Notifiarr`, `Ntfy`, `Pushover`, `Telegram` all do this) will pick it up automatically.
- The `EventPublisher` `failedImportReasons` payload is untouched — this PR is purely about user-visible notifications, not the internal event stream.

## How tested

- `dotnet build code/backend/Cleanuparr.Infrastructure/Cleanuparr.Infrastructure.csproj` — succeeds with 0 errors (only pre-existing CS86xx warnings in unrelated files).
- `dotnet build code/backend/Cleanuparr.Infrastructure.Tests/Cleanuparr.Infrastructure.Tests.csproj` — succeeds with 0 errors; existing tests in `StrikerIntegrationTests` that exercise `FailedImport` + `StatusMessages` flows still compile against the modified code path.
- Manual review of the producing flows: `ArrClient` already populates `QueueRecord.StatusMessages` from the *arr API for failed imports, and `EventPublisher.cs` line 134 already publishes them to the internal event stream — this PR uses the exact same source data, just in the notification path.