### PR TITLE
Add bulk dismiss and lazy paging for action required events

### DIFF
--- a/code/backend/Cleanuparr.Api/Controllers/ManualEventsController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/ManualEventsController.cs
@@ -142,6 +142,19 @@ public class ManualEventsController : ControllerBase
     }
 
     /// <summary>
+    /// Marks all unresolved manual events as resolved
+    /// </summary>
+    [HttpPost("resolve_all")]
+    public async Task<ActionResult<object>> ResolveAllManualEvents()
+    {
+        int resolvedCount = await _context.ManualEvents
+            .Where(e => !e.IsResolved)
+            .ExecuteUpdateAsync(setter => setter.SetProperty(e => e.IsResolved, true));
+
+        return Ok(new { ResolvedCount = resolvedCount });
+    }
+
+    /// <summary>
     /// Gets manual event statistics
     /// </summary>
     [HttpGet("stats")]

--- a/code/frontend/src/app/core/api/events.api.ts
+++ b/code/frontend/src/app/core/api/events.api.ts
@@ -70,6 +70,10 @@ export class EventsApi {
     return this.http.post<void>(`/api/manualevents/${id}/resolve`, {});
   }
 
+  resolveAllManualEvents(): Observable<{ resolvedCount: number }> {
+    return this.http.post<{ resolvedCount: number }>('/api/manualevents/resolve_all', {});
+  }
+
   getManualEventStats(): Observable<ManualEventStats> {
     return this.http.get<ManualEventStats>('/api/manualevents/stats');
   }

--- a/code/frontend/src/app/core/realtime/app-hub.service.ts
+++ b/code/frontend/src/app/core/realtime/app-hub.service.ts
@@ -130,7 +130,6 @@ export class AppHubService extends HubService {
   protected override onConnected(): void {
     this.requestRecentLogs();
     this.requestRecentEvents();
-    this.requestRecentManualEvents();
     this.requestRecentStrikes();
     this.requestJobStatus();
   }

--- a/code/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/code/frontend/src/app/features/dashboard/dashboard.component.html
@@ -22,19 +22,22 @@
     }
     <div class="manual-event__meta">
       <span class="manual-event__time">{{ event.timestamp | date:'short' }}</span>
-      @if (unresolvedManualEvents().length > 1) {
+      @if (manualEventCount() > 1) {
         <span class="manual-event__counter">
-          {{ manualEventIndex() + 1 }} of {{ unresolvedManualEvents().length }}
+          {{ manualEventIndex() + 1 }} of {{ manualEventCount() }}
         </span>
       }
     </div>
     <div class="manual-event__actions">
-      @if (unresolvedManualEvents().length > 1) {
+      @if (manualEventCount() > 1) {
         <app-button variant="ghost" size="sm" [disabled]="!canNavigatePrev()" (clicked)="prevManualEvent()">
           Previous
         </app-button>
-        <app-button variant="ghost" size="sm" [disabled]="!canNavigateNext()" (clicked)="nextManualEvent()">
+        <app-button variant="ghost" size="sm" [disabled]="!canNavigateNext() || loadingMoreManualEvents()" (clicked)="nextManualEvent()">
           Next
+        </app-button>
+        <app-button variant="ghost" size="sm" (clicked)="dismissAllManualEvents()">
+          Dismiss all
         </app-button>
       }
       <app-button variant="primary" size="sm" (clicked)="dismissManualEvent(event)">

--- a/code/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/code/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -13,6 +13,7 @@ import { JobsApi } from '@core/api/jobs.api';
 import { GeneralConfigApi } from '@core/api/general-config.api';
 import { CfScoreApi, CfScoreStats, CfScoreUpgradesResponse } from '@core/api/cf-score.api';
 import { ToastService } from '@core/services/toast.service';
+import { ConfirmService } from '@core/services/confirm.service';
 import { ManualEvent } from '@core/models/event.models';
 import { JobType } from '@shared/models/enums';
 
@@ -50,7 +51,14 @@ export class DashboardComponent {
   private readonly generalConfigApi = inject(GeneralConfigApi);
   private readonly cfScoreApi = inject(CfScoreApi);
   private readonly toast = inject(ToastService);
+  private readonly confirm = inject(ConfirmService);
   private readonly router = inject(Router);
+
+  private static readonly MANUAL_PAGE_SIZE = 20;
+
+  constructor() {
+    this.loadMoreManualEvents();
+  }
 
   readonly connected = this.hub.isConnected;
   readonly jobs = this.hub.jobs;
@@ -83,11 +91,36 @@ export class DashboardComponent {
   readonly recentLogs = computed(() => this.hub.logs().slice(0, 5));
   readonly recentEvents = computed(() => this.hub.events().slice(0, 5));
 
-  readonly unresolvedManualEvents = computed(() =>
-    this.hub.manualEvents().filter((e) => !e.isResolved)
-  );
+  // REST-paged backlog of unresolved manual events (lazily loaded page by page)
+  private readonly manualPages = signal<ManualEvent[]>([]);
+  private readonly manualNextPage = signal(1);
+  private readonly totalUnresolvedManualEvents = signal(0);
+  readonly loadingMoreManualEvents = signal(false);
+
+  // Merge live-pushed hub events with the lazily-paged backlog, newest first
+  readonly unresolvedManualEvents = computed(() => {
+    const byId = new Map<string, ManualEvent>();
+    for (const e of this.hub.manualEvents()) {
+      if (!e.isResolved) {
+        byId.set(e.id, e);
+      }
+    }
+    for (const e of this.manualPages()) {
+      if (!e.isResolved) {
+        byId.set(e.id, e);
+      }
+    }
+    return [...byId.values()].sort((a, b) =>
+      a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0
+    );
+  });
 
   readonly manualEventIndex = signal(0);
+
+  // True unresolved count; live pushes may exceed the last known server total
+  readonly manualEventCount = computed(() =>
+    Math.max(this.totalUnresolvedManualEvents(), this.unresolvedManualEvents().length)
+  );
 
   readonly currentManualEvent = computed(() => {
     const events = this.unresolvedManualEvents();
@@ -97,7 +130,7 @@ export class DashboardComponent {
 
   readonly canNavigatePrev = computed(() => this.manualEventIndex() > 0);
   readonly canNavigateNext = computed(() =>
-    this.manualEventIndex() < this.unresolvedManualEvents().length - 1
+    this.manualEventIndex() < this.manualEventCount() - 1
   );
 
   // Manual event navigation
@@ -108,15 +141,50 @@ export class DashboardComponent {
   }
 
   nextManualEvent(): void {
-    if (this.canNavigateNext()) {
-      this.manualEventIndex.update((i) => i + 1);
+    if (!this.canNavigateNext()) {
+      return;
     }
+    const nextIdx = this.manualEventIndex() + 1;
+    if (nextIdx >= this.unresolvedManualEvents().length) {
+      // Reached the end of what's loaded — lazily fetch the next page first
+      this.loadMoreManualEvents(() => {
+        const maxIdx = this.unresolvedManualEvents().length - 1;
+        this.manualEventIndex.set(Math.min(nextIdx, maxIdx));
+      });
+      return;
+    }
+    this.manualEventIndex.set(nextIdx);
+  }
+
+  private loadMoreManualEvents(after?: () => void): void {
+    if (this.loadingMoreManualEvents()) {
+      return;
+    }
+    this.loadingMoreManualEvents.set(true);
+    const page = this.manualNextPage();
+    this.eventsApi
+      .getManualEvents({ page, pageSize: DashboardComponent.MANUAL_PAGE_SIZE, isResolved: false })
+      .subscribe({
+        next: (res) => {
+          this.manualPages.update((cur) => [...cur, ...res.items]);
+          this.manualNextPage.set(page + 1);
+          this.totalUnresolvedManualEvents.set(res.totalCount);
+          this.loadingMoreManualEvents.set(false);
+          after?.();
+        },
+        error: () => {
+          this.loadingMoreManualEvents.set(false);
+          this.toast.error('Failed to load more events');
+        },
+      });
   }
 
   dismissManualEvent(event: ManualEvent): void {
     this.eventsApi.resolveManualEvent(event.id).subscribe({
       next: () => {
         this.hub.removeManualEvent(event.id);
+        this.manualPages.update((cur) => cur.filter((e) => e.id !== event.id));
+        this.totalUnresolvedManualEvents.update((t) => Math.max(0, t - 1));
         const maxIdx = this.unresolvedManualEvents().length - 1;
         if (this.manualEventIndex() > maxIdx) {
           this.manualEventIndex.set(Math.max(0, maxIdx));
@@ -124,6 +192,28 @@ export class DashboardComponent {
         this.toast.success('Event dismissed');
       },
       error: () => this.toast.error('Failed to dismiss event'),
+    });
+  }
+
+  async dismissAllManualEvents(): Promise<void> {
+    const confirmed = await this.confirm.confirm({
+      title: 'Dismiss all events',
+      message: `Dismiss all ${this.manualEventCount()} action required events? This marks them all as resolved.`,
+      confirmLabel: 'Dismiss all',
+    });
+    if (!confirmed) {
+      return;
+    }
+    this.eventsApi.resolveAllManualEvents().subscribe({
+      next: (res) => {
+        this.hub.clearManualEvents();
+        this.manualPages.set([]);
+        this.manualNextPage.set(1);
+        this.totalUnresolvedManualEvents.set(0);
+        this.manualEventIndex.set(0);
+        this.toast.success(`Dismissed ${res.resolvedCount} events`);
+      },
+      error: () => this.toast.error('Failed to dismiss events'),
     });
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce lazy REST paging and bulk dismissal for dashboard manual action-required events, and wire up frontend and backend support for resolving all manual events.

New Features:
- Support lazy-loaded paging of unresolved manual events on the dashboard, including navigation across server-paged backlogs.
- Add a bulk 'dismiss all' action for unresolved manual events with user confirmation and success/failure feedback.
- Expose a backend endpoint to resolve all unresolved manual events and return the number of events affected.

Enhancements:
- Unify live hub-pushed manual events with paged backlog data and track an accurate unresolved count for navigation and display.