### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/actions/vault-secrets/action.yml
+++ b/.github/actions/vault-secrets/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Get vault secrets
-      uses: hashicorp/vault-action@v2
+      uses: hashicorp/vault-action@v4
       with:
         url: ${{ inputs.vault_host }}
         method: approle

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -133,7 +133,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -144,7 +144,7 @@ jobs:
             secrets/data/github packages_pat | PACKAGES_PAT
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         timeout-minutes: 1
         with:
           repository: ${{ github.repository }}
@@ -153,15 +153,15 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         timeout-minutes: 5
 
       - name: Login to GitHub Container Registry
         if: needs.prepare.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -171,7 +171,7 @@ jobs:
         if: needs.prepare.outputs.push == 'true'
         id: build-push
         timeout-minutes: 30
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ github.workspace }}/code
           file: ${{ github.workspace }}/code/Dockerfile
@@ -191,7 +191,7 @@ jobs:
       - name: Build (no push)
         if: needs.prepare.outputs.push != 'true'
         timeout-minutes: 30
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ github.workspace }}/code
           file: ${{ github.workspace }}/code/Dockerfile
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload digest
         if: needs.prepare.outputs.push == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -231,17 +231,17 @@ jobs:
     if: needs.prepare.outputs.push == 'true'
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -9,6 +9,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   # Build for each platform in parallel using matrix strategy
   build-platform:

--- a/.github/workflows/build-executable.yml
+++ b/.github/workflows/build-executable.yml
@@ -55,7 +55,7 @@ jobs:
           echo "executableName=Cleanuparr.Api" >> $GITHUB_ENV
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -66,7 +66,7 @@ jobs:
             secrets/data/github packages_pat | PACKAGES_PAT
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         timeout-minutes: 1
         with:
           repository: ${{ env.githubRepository }}
@@ -75,12 +75,12 @@ jobs:
           persist-credentials: false
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.200
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
@@ -88,7 +88,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: code/frontend/dist/ui/browser
@@ -120,7 +120,7 @@ jobs:
           zip -r ./${{ env.githubRepositoryName }}-${{ env.appVersion }}-${{ matrix.platform }}.zip ./${{ env.githubRepositoryName }}-${{ env.appVersion }}-${{ matrix.platform }}/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: executable-${{ matrix.platform }}
           path: ./artifacts/*.zip

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -9,6 +9,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   build-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -24,7 +24,7 @@ jobs:
             secrets/data/github repo_readonly_pat | REPO_READONLY_PAT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         timeout-minutes: 1
         with:
           repository: ${{ github.repository }}
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '26'
           cache: 'npm'
@@ -46,7 +46,7 @@ jobs:
           npm run build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: frontend-dist
           path: code/frontend/dist/ui/browser

--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -59,7 +59,7 @@ jobs:
           echo "executableName=Cleanuparr.Api" >> $GITHUB_ENV
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -70,7 +70,7 @@ jobs:
             secrets/data/github packages_pat | PACKAGES_PAT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.githubRepository }}
           ref: ${{ github.ref_name }}
@@ -79,13 +79,13 @@ jobs:
           persist-credentials: false
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: code/frontend/dist/ui/browser
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.200
 
@@ -370,7 +370,7 @@ jobs:
           echo "pkgName=${pkg_name}" >> $GITHUB_ENV
 
       - name: Upload installer as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Cleanuparr-macos-${{ matrix.artifact_suffix }}-installer
           path: '${{ env.pkgName }}'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -14,6 +14,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   build-windows-installer:
     runs-on: windows-latest

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -49,7 +49,7 @@ jobs:
           echo "executableName=Cleanuparr.Api" >> $env:GITHUB_ENV
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -60,7 +60,7 @@ jobs:
             secrets/data/github packages_pat | PACKAGES_PAT
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ env.githubRepository }}
           ref: ${{ inputs.ref || github.ref_name }}
@@ -68,13 +68,13 @@ jobs:
           persist-credentials: false
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: code/frontend/dist/ui/browser
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.200
 
@@ -144,7 +144,7 @@ jobs:
           echo "installerName=$installerName" >> $env:GITHUB_ENV
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Cleanuparr-windows-installer
           path: installer/${{ env.installerName }}

--- a/.github/workflows/cloudflare-pages-blocklists.yml
+++ b/.github/workflows/cloudflare-pages-blocklists.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -35,7 +35,7 @@ jobs:
           cp whitelist_with_subtitles Cloudflare/static/
       
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           workingDirectory: "Cloudflare"

--- a/.github/workflows/cloudflare-pages-blocklists.yml
+++ b/.github/workflows/cloudflare-pages-blocklists.yml
@@ -12,6 +12,9 @@ on:
       - 'whitelist_with_subtitles'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloudflare-pages-status.yml
+++ b/.github/workflows/cloudflare-pages-status.yml
@@ -14,6 +14,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloudflare-pages-status.yml
+++ b/.github/workflows/cloudflare-pages-status.yml
@@ -32,7 +32,7 @@ jobs:
           EOF
       
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           workingDirectory: "status"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           # Fail on critical and high severity vulnerabilities
           fail-on-severity: high
@@ -39,7 +39,7 @@ jobs:
           vulnerability-check: true
 
       - name: Upload dependency review results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-review-results
           path: dependency-review-*.json

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -20,12 +20,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 26.x
           cache: yarn
@@ -40,14 +40,14 @@ jobs:
         run: yarn build
 
       - name: Deploy preview to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}
           workingDirectory: docs
           command: pages deploy build --project-name=cleanuparr-docs --branch=pull-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const url = `https://pull-${context.issue.number}.cleanuparr-docs.pages.dev`;

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 26.x
           cache: yarn
@@ -63,11 +63,11 @@ jobs:
           cp redirect/404.html redirect/index.html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: redirect
           retention-days: 1
 
       - name: Deploy redirect to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,13 +41,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         timeout-minutes: 1
         with:
           persist-credentials: false
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -64,7 +64,7 @@ jobs:
           PACKAGES_PAT: ${{ env.PACKAGES_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 26
 
@@ -94,7 +94,7 @@ jobs:
         run: npx playwright test --project=${{ matrix.suite.name }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: e2e-test-results-${{ matrix.suite.name }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -137,11 +137,13 @@ jobs:
     steps:
       - name: Post result comment
         uses: actions/github-script@v9
+        env:
+          PR_REF: ${{ needs.validate.outputs.pr_ref }}
         with:
           script: |
             const buildResult = '${{ needs.build-windows.result }}';
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const prRef = '${{ needs.validate.outputs.pr_ref }}';
+            const prRef = process.env.PR_REF;
             const prSha = '${{ needs.validate.outputs.pr_sha }}';
             const shortSha = prSha.substring(0, 7);
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Parse command and check permissions
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const comment = context.payload.comment.body.trim();
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Post result comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const buildResult = '${{ needs.build-windows.result }}';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -195,7 +195,7 @@ jobs:
     
     steps:
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -205,20 +205,20 @@ jobs:
             secrets/data/github repo_readonly_pat | REPO_READONLY_PAT
 
       - name: Download executable artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: executable-*
           path: ./artifacts
           merge-multiple: true
 
       - name: Download Windows installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Cleanuparr-windows-installer
           path: ./artifacts
 
       - name: Download macOS installers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: Cleanuparr-macos-*-installer
           path: ./artifacts
@@ -232,7 +232,7 @@ jobs:
           echo "Total files: $(find ./artifacts -type f \( -name "*.zip" -o -name "*.pkg" -o -name "*.exe" \) | wc -l)"
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ needs.validate.outputs.release_version }}
           tag_name: ${{ needs.validate.outputs.release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Validate release
   validate:
@@ -166,6 +169,9 @@ jobs:
   # Build and push Docker image(s)
   build-docker:
     needs: [validate, test, e2e]
+    permissions:
+      contents: read
+      packages: write
     if: |
       always() &&
       needs.validate.result == 'success' &&
@@ -269,6 +275,8 @@ jobs:
   summary:
     needs: [validate, test, e2e, build-frontend, build-executables, build-windows-installer, build-macos, build-docker]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     if: always()
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,14 @@ concurrency:
   group: Tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,18 +25,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         timeout-minutes: 1
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.200
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
@@ -44,7 +44,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Get vault secrets
-        uses: hashicorp/vault-action@v2
+        uses: hashicorp/vault-action@v4
         with:
           url: ${{ secrets.VAULT_HOST }}
           method: approle
@@ -66,21 +66,21 @@ jobs:
         run: dotnet test code/backend/cleanuparr.sln --configuration Release --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" --settings code/backend/coverage.runsettings --results-directory ./coverage
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: ./coverage/*.trx
           retention-days: 30
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: ./coverage/**/coverage.cobertura.xml
           retention-days: 30
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/**/coverage.cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/version-info.yml
+++ b/.github/workflows/version-info.yml
@@ -22,6 +22,9 @@ on:
         description: 'Repository name without owner'
         value: ${{ jobs.version.outputs.repository_name }}
 
+permissions:
+  contents: read
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflows to use newer action versions and enforce explicit permissions across CI and release pipelines.

CI:
- Upgrade various GitHub Actions (checkout, cache, setup-node, setup-dotnet, upload/download-artifact, Docker, Codecov, Cloudflare Wrangler, dependency-review, GitHub Script, pages-related actions, vault-action) to their latest major versions in all workflows.
- Add explicit, least-privilege permissions blocks (contents, packages, actions) to multiple workflows including release, tests, build executables/installers, Cloudflare deployments, and version-info.
- Restrict test workflow runs for pull requests to those originating from the same repository to avoid running CI on forks.