### PR TITLE
Add option to ignore specific download clients for Queue Cleaner and Malware Blocker

### DIFF
--- a/code/backend/Cleanuparr.Domain/Entities/Arr/Queue/QueueRecord.cs
+++ b/code/backend/Cleanuparr.Domain/Entities/Arr/Queue/QueueRecord.cs
@@ -35,6 +35,7 @@ public sealed record QueueRecord
     public string TrackedDownloadState { get; init; }
     public List<TrackedDownloadStatusMessage>? StatusMessages { get; init; }
     public required string DownloadId { get; init; }
+    public string? DownloadClient { get; init; }
     public required string Protocol { get; init; }
     public required long Id { get; init; }
     public long SizeLeft { get; init; }

--- a/code/backend/Cleanuparr.Domain/Entities/Arr/Queue/QueueRecordExtensions.cs
+++ b/code/backend/Cleanuparr.Domain/Entities/Arr/Queue/QueueRecordExtensions.cs
@@ -1,0 +1,24 @@
+namespace Cleanuparr.Domain.Entities.Arr.Queue;
+
+public static class QueueRecordExtensions
+{
+    public static bool IsIgnored(this QueueRecord record, IReadOnlyList<string> ignoredDownloads)
+    {
+        bool hasDownloadClient = !string.IsNullOrWhiteSpace(record.DownloadClient);
+
+        foreach (string ignored in ignoredDownloads)
+        {
+            if (record.DownloadId.Equals(ignored, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            if (hasDownloadClient && record.DownloadClient!.Equals(ignored, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/MalwareBlockerTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/MalwareBlockerTests.cs
@@ -256,7 +256,7 @@ public class MalwareBlockerTests : IDisposable
         {
             Id = 1,
             DownloadId = "not-a-valid-hash",
-            DownloadClient = "myDownloadClient",
+            DownloadClient = "MYDOWNLOADCLIENT",
             Title = "Ignored By Client",
             Protocol = "torrent",
             SeriesId = 1,

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/MalwareBlockerTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/MalwareBlockerTests.cs
@@ -233,6 +233,58 @@ public class MalwareBlockerTests : IDisposable
     }
 
     [Fact]
+    public async Task ProcessInstanceAsync_SkipsDownloadsIgnoredByClientName()
+    {
+        // Arrange
+        var generalConfig = _fixture.DataContext.GeneralConfigs.First();
+        generalConfig.IgnoredDownloads = ["myDownloadClient"];
+        _fixture.DataContext.SaveChanges();
+
+        TestDataContextFactory.AddDownloadClient(_fixture.DataContext);
+        EnableSonarrBlocklist();
+        TestDataContextFactory.AddSonarrInstance(_fixture.DataContext);
+
+        var mockArrClient = Substitute.For<IArrClient>();
+        mockArrClient.IsRecordValid(Arg.Any<QueueRecord>()).Returns(true);
+        mockArrClient.HasContentId(Arg.Any<QueueRecord>()).Returns(true);
+
+        _fixture.ArrClientFactory
+            .GetClient(InstanceType.Sonarr, Arg.Any<float>())
+            .Returns(mockArrClient);
+
+        var queueRecord = new QueueRecord
+        {
+            Id = 1,
+            DownloadId = "not-a-valid-hash",
+            DownloadClient = "myDownloadClient",
+            Title = "Ignored By Client",
+            Protocol = "torrent",
+            SeriesId = 1,
+            EpisodeId = 1
+        };
+
+        _fixture.ArrQueueIterator
+            .Iterate(
+                Arg.Any<IArrClient>(),
+                Arg.Any<ArrInstance>(),
+                Arg.Any<Func<IReadOnlyList<QueueRecord>, Task>>()
+            )
+            .Returns(ci =>
+            {
+                var callback = ci.ArgAt<Func<IReadOnlyList<QueueRecord>, Task>>(2);
+                return callback([queueRecord]);
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert
+        _logger.ReceivedLogContaining(LogLevel.Information, "ignored");
+    }
+
+    [Fact]
     public async Task ProcessInstanceAsync_ChecksTorrentClientsForBlockedFiles()
     {
         // Arrange

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/QueueCleanerTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/QueueCleanerTests.cs
@@ -223,6 +223,57 @@ public class QueueCleanerTests : IDisposable
     }
 
     [Fact]
+    public async Task ProcessInstanceAsync_SkipsDownloadsIgnoredByClientName()
+    {
+        // Arrange
+        var generalConfig = _fixture.DataContext.GeneralConfigs.First();
+        generalConfig.IgnoredDownloads = ["myDownloadClient"];
+        _fixture.DataContext.SaveChanges();
+
+        TestDataContextFactory.AddSonarrInstance(_fixture.DataContext);
+        TestDataContextFactory.AddDownloadClient(_fixture.DataContext);
+
+        var mockArrClient = Substitute.For<IArrClient>();
+        mockArrClient.IsRecordValid(Arg.Any<QueueRecord>()).Returns(true);
+        mockArrClient.HasContentId(Arg.Any<QueueRecord>()).Returns(true);
+
+        _fixture.ArrClientFactory
+            .GetClient(InstanceType.Sonarr, Arg.Any<float>())
+            .Returns(mockArrClient);
+
+        var queueRecord = new QueueRecord
+        {
+            Id = 1,
+            DownloadId = "not-a-valid-hash",
+            DownloadClient = "myDownloadClient",
+            Title = "Ignored By Client",
+            Protocol = "torrent",
+            SeriesId = 1,
+            EpisodeId = 1
+        };
+
+        _fixture.ArrQueueIterator
+            .Iterate(
+                Arg.Any<IArrClient>(),
+                Arg.Any<ArrInstance>(),
+                Arg.Any<Func<IReadOnlyList<QueueRecord>, Task>>()
+            )
+            .Returns(async ci =>
+            {
+                var callback = ci.ArgAt<Func<IReadOnlyList<QueueRecord>, Task>>(2);
+                await callback([queueRecord]);
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.ExecuteAsync();
+
+        // Assert
+        _logger.ReceivedLogContaining(LogLevel.Information, "download is ignored");
+    }
+
+    [Fact]
     public async Task ProcessInstanceAsync_SkipsAlreadyCachedDownloads()
     {
         // Arrange

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/QueueCleanerTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/QueueCleanerTests.cs
@@ -245,7 +245,7 @@ public class QueueCleanerTests : IDisposable
         {
             Id = 1,
             DownloadId = "not-a-valid-hash",
-            DownloadClient = "myDownloadClient",
+            DownloadClient = "MYDOWNLOADCLIENT",
             Title = "Ignored By Client",
             Protocol = "torrent",
             SeriesId = 1,

--- a/code/backend/Cleanuparr.Infrastructure/Features/Jobs/MalwareBlocker.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Jobs/MalwareBlocker.cs
@@ -129,7 +129,7 @@ public sealed class MalwareBlocker : GenericHandler
                     continue;
                 }
 
-                if (ignoredDownloads.Contains(record.DownloadId, StringComparer.InvariantCultureIgnoreCase))
+                if (record.IsIgnored(ignoredDownloads))
                 {
                     _logger.LogInformation("skip | {title} | ignored", record.Title);
                     continue;

--- a/code/backend/Cleanuparr.Infrastructure/Features/Jobs/QueueCleaner.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Jobs/QueueCleaner.cs
@@ -117,7 +117,7 @@ public sealed class QueueCleaner : GenericHandler
                     continue;
                 }
                 
-                if (ignoredDownloads.Contains(record.DownloadId, StringComparer.InvariantCultureIgnoreCase))
+                if (record.IsIgnored(ignoredDownloads))
                 {
                     _logger.LogInformation("skip | download is ignored | {name}", record.Title);
                     continue;

--- a/code/frontend/src/app/features/settings/general/general-settings.component.html
+++ b/code/frontend/src/app/features/settings/general/general-settings.component.html
@@ -34,7 +34,7 @@
       <app-chip-input
         label="Ignored Downloads"
         placeholder="Add download pattern..."
-        hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker)"
+        hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker, or the download client name from your *arrs). Download client name matching applies to Queue Cleaner and Malware Blocker only."
         [formField]="genForm.ignoredDownloads"
         helpKey="general:ignoredDownloads"
       />

--- a/code/frontend/src/app/features/settings/malware-blocker/malware-blocker.component.html
+++ b/code/frontend/src/app/features/settings/malware-blocker/malware-blocker.component.html
@@ -63,7 +63,7 @@
         <app-chip-input
           label="Ignored Downloads"
           placeholder="Add download pattern..."
-          hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker)"
+          hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker, or the download client name from your *arrs)"
           [formField]="mbForm.ignoredDownloads"
           helpKey="malware-blocker:ignoredDownloads"
         />

--- a/code/frontend/src/app/features/settings/queue-cleaner/queue-cleaner.component.html
+++ b/code/frontend/src/app/features/settings/queue-cleaner/queue-cleaner.component.html
@@ -50,7 +50,7 @@
         <app-chip-input
           label="Ignored Downloads"
           placeholder="Add download pattern..."
-          hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker)"
+          hint="Downloads matching these patterns will be ignored (e.g. hash, tag, category, label, tracker, or the download client name from your *arrs)"
           [formField]="qcForm.ignoredDownloads"
           helpKey="queue-cleaner:ignoredDownloads"
         />

--- a/docs/docs/configuration/general/index.mdx
+++ b/docs/docs/configuration/general/index.mdx
@@ -156,6 +156,7 @@ Downloads matching these patterns are skipped during all cleaning operations. Ma
 - µTorrent label
 - rtorrent label
 - Tracker domain
+- Download client name as configured in your *arrs (Queue Cleaner and Malware Blocker only)
 
 **Examples:**
 ```
@@ -163,6 +164,7 @@ fa800a7d7c443a2c3561d1f8f393c089036dade1
 tv-sonarr
 qbit-tag
 mytracker.com
+myDownloadClient
 ```
 
 </ConfigSection>

--- a/docs/docs/configuration/malware-blocker/index.mdx
+++ b/docs/docs/configuration/malware-blocker/index.mdx
@@ -69,6 +69,7 @@ Downloads matching these patterns will be ignored by Malware Blocker. Patterns c
 - µTorrent label
 - rtorrent label
 - torrent tracker domain
+- download client name as configured in your *arrs
 
 **Examples:**
 ```
@@ -76,6 +77,7 @@ fa800a7d7c443a2c3561d1f8f393c089036dade1
 tv-sonarr
 qbit-tag
 mytracker.com
+myDownloadClient
 ```
 
 </ConfigSection>

--- a/docs/docs/configuration/queue-cleaner/index.mdx
+++ b/docs/docs/configuration/queue-cleaner/index.mdx
@@ -68,6 +68,7 @@ Downloads matching these patterns will be ignored by Queue Cleaner. Patterns can
 - µTorrent label
 - rtorrent label
 - torrent tracker domain
+- download client name as configured in your *arrs
 
 **Examples:**
 ```
@@ -75,6 +76,7 @@ fa800a7d7c443a2c3561d1f8f393c089036dade1
 tv-sonarr
 qbit-tag
 mytracker.com
+myDownloadClient
 ```
 
 </ConfigSection>


### PR DESCRIPTION
Relates to #664.

## Summary by Sourcery

Support ignoring queue items by download client name for Queue Cleaner and Malware Blocker, and document this behavior in settings and configuration docs.

New Features:
- Allow Malware Blocker and Queue Cleaner to skip downloads based on matching the *arr download client name in the ignored downloads configuration.

Enhancements:
- Introduce a QueueRecord extension method to centralize ignored download matching by ID and client name.

Documentation:
- Update general, Malware Blocker, and Queue Cleaner configuration docs and UI hints to mention download client name as a supported ignored pattern.

Tests:
- Add unit tests verifying that Malware Blocker and Queue Cleaner skip downloads when their client name is present in the ignored downloads list.