### PR TITLE
Fix dead torrent detection flagging completed torrents

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/DeadTorrentServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Jobs/DeadTorrentServiceTests.cs
@@ -65,7 +65,7 @@ public sealed class DeadTorrentServiceTests : IDisposable
         _dataContext.SaveChanges();
     }
 
-    private static ITorrentItemWrapper CreateTorrent(string hash, string category, int? seederCount, string[]? tags = null)
+    private static ITorrentItemWrapper CreateTorrent(string hash, string category, int? seederCount, string[]? tags = null, double completionPercentage = 0)
     {
         var torrent = Substitute.For<ITorrentItemWrapper>();
         torrent.Hash.Returns(hash);
@@ -73,6 +73,7 @@ public sealed class DeadTorrentServiceTests : IDisposable
         torrent.Category.Returns(category);
         torrent.SeederCount.Returns(seederCount);
         torrent.Tags.Returns(tags ?? Array.Empty<string>());
+        torrent.CompletionPercentage.Returns(completionPercentage);
         return torrent;
     }
 
@@ -136,6 +137,49 @@ public sealed class DeadTorrentServiceTests : IDisposable
 
         await _striker.Received(1).ResetStrikeAsync("hash1", Arg.Any<string>(), StrikeType.DeadTorrent);
         await _striker.DidNotReceiveWithAnyArgs().StrikeAndCheckLimit(default!, default!, default, default);
+        await _downloadService.DidNotReceiveWithAnyArgs().ChangeTorrentCategoryAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task CompletedTorrent_WithZeroSeeders_DoesNotStrikeOrMove()
+    {
+        AddConfig();
+        _striker.StrikeAndCheckLimit(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ushort>(), StrikeType.DeadTorrent)
+            .Returns(true);
+        var downloads = new List<ITorrentItemWrapper> { CreateTorrent("hash1", "movies", 0, completionPercentage: 100) };
+
+        await _sut.ProcessAsync(_downloadService, downloads);
+
+        await _striker.DidNotReceiveWithAnyArgs().StrikeAndCheckLimit(default!, default!, default, default);
+        await _striker.DidNotReceiveWithAnyArgs().ResetStrikeAsync(default!, default!, default);
+        await _downloadService.DidNotReceiveWithAnyArgs().ChangeTorrentCategoryAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task CompletedTorrent_WithUnavailableSeederCount_DoesNotStrikeOrMove()
+    {
+        AddConfig();
+        _striker.StrikeAndCheckLimit(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ushort>(), StrikeType.DeadTorrent)
+            .Returns(true);
+        var downloads = new List<ITorrentItemWrapper> { CreateTorrent("hash1", "movies", null, completionPercentage: 100) };
+
+        await _sut.ProcessAsync(_downloadService, downloads);
+
+        await _striker.DidNotReceiveWithAnyArgs().StrikeAndCheckLimit(default!, default!, default, default);
+        await _striker.DidNotReceiveWithAnyArgs().ResetStrikeAsync(default!, default!, default);
+        await _downloadService.DidNotReceiveWithAnyArgs().ChangeTorrentCategoryAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task CompletedTorrent_WithSeeders_DoesNotResetStrikes()
+    {
+        AddConfig();
+        var downloads = new List<ITorrentItemWrapper> { CreateTorrent("hash1", "movies", 5, completionPercentage: 100) };
+
+        await _sut.ProcessAsync(_downloadService, downloads);
+
+        await _striker.DidNotReceiveWithAnyArgs().StrikeAndCheckLimit(default!, default!, default, default);
+        await _striker.DidNotReceiveWithAnyArgs().ResetStrikeAsync(default!, default!, default);
         await _downloadService.DidNotReceiveWithAnyArgs().ChangeTorrentCategoryAsync(default!, default!, default);
     }
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadCleaner/Services/DeadTorrentService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadCleaner/Services/DeadTorrentService.cs
@@ -47,6 +47,7 @@ public sealed class DeadTorrentService : IDeadTorrentService
         List<ITorrentItemWrapper> candidates = clientDownloads
             .Where(t => !string.IsNullOrEmpty(t.Hash))
             .Where(t => config.Categories.Any(cat => cat.Equals(t.Category, StringComparison.OrdinalIgnoreCase)))
+            .Where(t => t.CompletionPercentage < 100)
             .Where(t => config.UseTag
                 ? !t.Tags.Contains(config.TargetCategory, StringComparer.OrdinalIgnoreCase)
                 : !config.TargetCategory.Equals(t.Category, StringComparison.OrdinalIgnoreCase))

--- a/docs/docs/configuration/download-cleaner/index.mdx
+++ b/docs/docs/configuration/download-cleaner/index.mdx
@@ -420,10 +420,13 @@ Categories to check for unlinked downloads. Only downloads in these categories w
 
 <p className={styles.sectionDescription}>
   A dead torrent is one whose tracker reports no seeders for a prolonged period — typically because it was removed from the tracker, or the tracker host itself is gone — so it can never reach a ratio or seed-time threshold. Instead of deleting such torrents, this feature moves them to a target category (or adds a tag/label) so you can decide what to do next via a seeding rule for that category/tag. It runs as part of the Download Cleaner job. Configured per download client in the <strong>Dead Torrents</strong> accordion.
+
+Only **partial downloads** are ever considered dead — completed torrents are excluded entirely, since a finished torrent is seeding and should keep seeding regardless of its current upload rate. So a completed torrent that has simply not been leeched yet (idle seeders, no active connections) is never flagged.
+
 </p>
 
 <Note>
-A torrent is considered dead on a run when the client reports **no seeders** — a count of `0`, an unknown count (e.g. qBittorrent's `-1`), or no count at all because the tracker is unreachable. It is only moved after it has been dead for the configured number of consecutive runs (the strike count), and **strikes reset to zero as soon as the client reports seeders again**. Supported for **qBittorrent**, **Transmission**, **Deluge**, and **µTorrent** — not **rTorrent**, which does not report a seeder count.
+A torrent is considered dead on a run when the client reports **no seeders** — a count of `0`, an unknown count (e.g. qBittorrent's `-1`), or no count at all because the tracker is unreachable. **Completed torrents are never considered dead** — only partial downloads are scanned. A torrent is moved after it has been dead for the configured number of consecutive runs (the strike count), and **strikes reset to zero as soon as the client reports seeders again**. Supported for **qBittorrent**, **Transmission**, **Deluge**, and **µTorrent** — not **rTorrent**, which does not report a seeder count.
 </Note>
 
 <ConfigSection


### PR DESCRIPTION
## Description
The dead-torrent feature strikes any torrent in the configured categories that reports no seeders, regardless of whether the torrent is still downloading. Completed torrents that are seeding (e.g. idle seeders with no active leecher connections) report `0` connected seeders in qBittorrent, so they get struck as "dead" and can eventually be moved to the dead category — even though they should keep seeding indefinitely.

This scopes dead-torrent detection to **partial downloads only**: a torrent is only a dead-torrent candidate while `CompletionPercentage < 100`. Completed torrents are excluded entirely (never struck, never reset, never moved), so they keep seeding for as long as the seeding rules allow regardless of current upload activity.

## Related Issue
N/A — fixes the false-positive behaviour observed in the dead-torrent feature.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
- Added 3 unit tests to `DeadTorrentServiceTests`:
  - completed torrent + zero seeders → does not strike or move
  - completed torrent + unavailable seeder count → does not strike or move
  - completed torrent + seeders → does not reset strikes (untouched)
- Full backend suite passes: Infrastructure 1866/1866, API 334/334, Persistence 704/704.
- Verified live for 2+ hourly runs on a qBittorrent download client: previously-affected completed torrents (DS9 season packs, Community S03 — all `progress: 1.0`, `stalledUP`) no longer receive DeadTorrent strikes.

## Checklist
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] I have announced my intent to work on this and received approval
- [x] My code follows the project's code standards
- [x] I have tested my changes thoroughly
- [x] I have updated relevant documentation