### PR TITLE
Fix OIDC discovery client never picking up DNS changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,9 @@ Cleanuparr/
 - Use meaningful names - avoid abbreviations unless widely understood
 - Keep services focused - single responsibility principle
 - New integrations go under `Features/` subdirectories (e.g., `Infrastructure/Features/Arr/`)
+- **One type per file** - every class, record, struct and enum lives in its own file, named after it
+- **Split as you go** - when a change touches a file holding several types, split that file as part of the change
+- Exception: a test double used by a single spec may stay nested in that spec; doubles shared across specs go in `TestHelpers/`
 
 ### Frontend (TypeScript/Angular)
 - All components must be **standalone** with **ChangeDetectionStrategy.OnPush**

--- a/code/backend/Cleanuparr.Api/DependencyInjection/MainDI.cs
+++ b/code/backend/Cleanuparr.Api/DependencyInjection/MainDI.cs
@@ -6,6 +6,7 @@ using Cleanuparr.Infrastructure.Features.Notifications.Models;
 using Cleanuparr.Infrastructure.Health;
 using Cleanuparr.Infrastructure.Http;
 using Cleanuparr.Infrastructure.Http.DynamicHttpClientSystem;
+using Cleanuparr.Shared.Helpers;
 using MassTransit;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -75,10 +76,10 @@ public static class MainDI
         services.AddSingleton<IDynamicHttpClientProvider, DynamicHttpClientProvider>();
 
         // Add HTTP client for Plex authentication
-        services.AddHttpClient("PlexAuth");
+        services.AddHttpClient(Constants.HttpClientPlexAuthName);
 
         // Add HTTP client for OIDC authentication
-        services.AddHttpClient("OidcAuth");
+        services.AddHttpClient(Constants.HttpClientOidcAuthName);
 
         return services;
     }

--- a/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateAuthConfigRequest.cs
+++ b/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateAuthConfigRequest.cs
@@ -1,0 +1,19 @@
+using Cleanuparr.Persistence.Models.Configuration.General;
+
+namespace Cleanuparr.Api.Features.General.Contracts.Requests;
+
+public sealed record UpdateAuthConfigRequest
+{
+    public bool DisableAuthForLocalAddresses { get; init; }
+
+    public bool TrustForwardedHeaders { get; init; }
+
+    public List<string> TrustedNetworks { get; init; } = [];
+
+    public void ApplyTo(AuthConfig existingConfig)
+    {
+        existingConfig.DisableAuthForLocalAddresses = DisableAuthForLocalAddresses;
+        existingConfig.TrustForwardedHeaders = TrustForwardedHeaders;
+        existingConfig.TrustedNetworks = TrustedNetworks;
+    }
+}

--- a/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateGeneralConfigRequest.cs
+++ b/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateGeneralConfigRequest.cs
@@ -2,7 +2,6 @@ using Cleanuparr.Domain.Enums;
 using Cleanuparr.Infrastructure.Http.DynamicHttpClientSystem;
 using Cleanuparr.Infrastructure.Logging;
 using Cleanuparr.Persistence.Models.Configuration.General;
-using Serilog.Events;
 
 namespace Cleanuparr.Api.Features.General.Contracts.Requests;
 
@@ -82,66 +81,5 @@ public sealed record UpdateGeneralConfigRequest
 
         logger.LogCritical("Reconfiguring logger due to configuration changes");
         LoggingConfigManager.ReconfigureLogging(config);
-    }
-}
-
-public sealed record UpdateLoggingConfigRequest
-{
-    public LogEventLevel Level { get; init; } = LogEventLevel.Information;
-
-    public ushort RollingSizeMB { get; init; } = 10;
-
-    public ushort RetainedFileCount { get; init; } = 5;
-
-    public ushort TimeLimitHours { get; init; } = 24;
-
-    public bool ArchiveEnabled { get; init; } = true;
-
-    public ushort ArchiveRetainedCount { get; init; } = 60;
-
-    public ushort ArchiveTimeLimitHours { get; init; } = 24 * 30;
-
-    public bool ApplyTo(LoggingConfig existingConfig)
-    {
-        bool levelChanged = existingConfig.Level != Level;
-        bool otherPropertiesChanged =
-            existingConfig.RollingSizeMB != RollingSizeMB ||
-            existingConfig.RetainedFileCount != RetainedFileCount ||
-            existingConfig.TimeLimitHours != TimeLimitHours ||
-            existingConfig.ArchiveEnabled != ArchiveEnabled ||
-            existingConfig.ArchiveRetainedCount != ArchiveRetainedCount ||
-            existingConfig.ArchiveTimeLimitHours != ArchiveTimeLimitHours;
-
-        existingConfig.Level = Level;
-        existingConfig.RollingSizeMB = RollingSizeMB;
-        existingConfig.RetainedFileCount = RetainedFileCount;
-        existingConfig.TimeLimitHours = TimeLimitHours;
-        existingConfig.ArchiveEnabled = ArchiveEnabled;
-        existingConfig.ArchiveRetainedCount = ArchiveRetainedCount;
-        existingConfig.ArchiveTimeLimitHours = ArchiveTimeLimitHours;
-
-        existingConfig.Validate();
-
-        LevelOnlyChange = levelChanged && !otherPropertiesChanged;
-
-        return levelChanged || otherPropertiesChanged;
-    }
-
-    public bool LevelOnlyChange { get; private set; }
-}
-
-public sealed record UpdateAuthConfigRequest
-{
-    public bool DisableAuthForLocalAddresses { get; init; }
-
-    public bool TrustForwardedHeaders { get; init; }
-
-    public List<string> TrustedNetworks { get; init; } = [];
-
-    public void ApplyTo(AuthConfig existingConfig)
-    {
-        existingConfig.DisableAuthForLocalAddresses = DisableAuthForLocalAddresses;
-        existingConfig.TrustForwardedHeaders = TrustForwardedHeaders;
-        existingConfig.TrustedNetworks = TrustedNetworks;
     }
 }

--- a/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateLoggingConfigRequest.cs
+++ b/code/backend/Cleanuparr.Api/Features/General/Contracts/Requests/UpdateLoggingConfigRequest.cs
@@ -1,0 +1,49 @@
+using Cleanuparr.Persistence.Models.Configuration.General;
+using Serilog.Events;
+
+namespace Cleanuparr.Api.Features.General.Contracts.Requests;
+
+public sealed record UpdateLoggingConfigRequest
+{
+    public LogEventLevel Level { get; init; } = LogEventLevel.Information;
+
+    public ushort RollingSizeMB { get; init; } = 10;
+
+    public ushort RetainedFileCount { get; init; } = 5;
+
+    public ushort TimeLimitHours { get; init; } = 24;
+
+    public bool ArchiveEnabled { get; init; } = true;
+
+    public ushort ArchiveRetainedCount { get; init; } = 60;
+
+    public ushort ArchiveTimeLimitHours { get; init; } = 24 * 30;
+
+    public bool ApplyTo(LoggingConfig existingConfig)
+    {
+        bool levelChanged = existingConfig.Level != Level;
+        bool otherPropertiesChanged =
+            existingConfig.RollingSizeMB != RollingSizeMB ||
+            existingConfig.RetainedFileCount != RetainedFileCount ||
+            existingConfig.TimeLimitHours != TimeLimitHours ||
+            existingConfig.ArchiveEnabled != ArchiveEnabled ||
+            existingConfig.ArchiveRetainedCount != ArchiveRetainedCount ||
+            existingConfig.ArchiveTimeLimitHours != ArchiveTimeLimitHours;
+
+        existingConfig.Level = Level;
+        existingConfig.RollingSizeMB = RollingSizeMB;
+        existingConfig.RetainedFileCount = RetainedFileCount;
+        existingConfig.TimeLimitHours = TimeLimitHours;
+        existingConfig.ArchiveEnabled = ArchiveEnabled;
+        existingConfig.ArchiveRetainedCount = ArchiveRetainedCount;
+        existingConfig.ArchiveTimeLimitHours = ArchiveTimeLimitHours;
+
+        existingConfig.Validate();
+
+        LevelOnlyChange = levelChanged && !otherPropertiesChanged;
+
+        return levelChanged || otherPropertiesChanged;
+    }
+
+    public bool LevelOnlyChange { get; private set; }
+}

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Auth/OidcAuthServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Auth/OidcAuthServiceTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Cleanuparr.Infrastructure.Features.Auth;
+using Cleanuparr.Infrastructure.Features.Auth.Models;
 using Microsoft.IdentityModel.Tokens;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Auth;
@@ -751,9 +752,7 @@ public sealed class OidcAuthServiceTests : IDisposable
             .GetField("OneTimeCodes", BindingFlags.NonPublic | BindingFlags.Static)!;
         var oneTimeCodes = oneTimeCodesField.GetValue(null)!;
 
-        var entryType = typeof(OidcAuthService)
-            .GetNestedType("OidcOneTimeCodeEntry", BindingFlags.NonPublic)!;
-        var entry = Activator.CreateInstance(entryType)!;
+        var entry = Activator.CreateInstance(typeof(OidcOneTimeCodeEntry))!;
 
         SetReflectionProperty(entry, "AccessToken", "test-access");
         SetReflectionProperty(entry, "RefreshToken", "test-refresh");
@@ -800,9 +799,7 @@ public sealed class OidcAuthServiceTests : IDisposable
             .GetField("PendingFlows", BindingFlags.NonPublic | BindingFlags.Static)!;
         var pendingFlows = pendingFlowsField.GetValue(null)!;
 
-        var flowType = typeof(OidcAuthService)
-            .GetNestedType("OidcFlowState", BindingFlags.NonPublic)!;
-        var entry = Activator.CreateInstance(flowType)!;
+        var entry = Activator.CreateInstance(typeof(OidcFlowState))!;
         var key = "capacity-test-" + Guid.NewGuid().ToString("N");
 
         SetReflectionProperty(entry, "State", key);

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/Auth/OidcAuthServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/Auth/OidcAuthServiceTests.cs
@@ -167,6 +167,34 @@ public sealed class OidcAuthServiceTests : IDisposable
             () => service.StartAuthorization("https://app.test/api/auth/oidc/callback"));
     }
 
+    [Fact]
+    public async Task StartAuthorization_TakesAFreshClientFromTheFactoryToFetchDiscovery()
+    {
+        OidcAuthService.ClearDiscoveryCache();
+        await EnableOidcInConfig();
+
+        MockHttpMessageHandler handler = CreateDiscoveryHandler();
+        IHttpClientFactory factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("OidcAuth").Returns(_ => new HttpClient(handler));
+
+        OidcAuthService service = new(factory, _usersContext, _logger);
+
+        // Drops the call the constructor made.
+        // What remains is what the discovery fetch asks for.
+        factory.ClearReceivedCalls();
+
+        try
+        {
+            await service.StartAuthorization(MockRedirectUri);
+
+            factory.Received().CreateClient("OidcAuth");
+        }
+        finally
+        {
+            OidcAuthService.ClearDiscoveryCache();
+        }
+    }
+
     #endregion
 
     #region HandleCallback Tests

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/FactoryDocumentRetriever.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/FactoryDocumentRetriever.cs
@@ -1,0 +1,19 @@
+using Cleanuparr.Shared.Helpers;
+using Microsoft.IdentityModel.Protocols;
+
+namespace Cleanuparr.Infrastructure.Features.Auth;
+
+/// <summary>
+/// Fetches the OIDC discovery document with a fresh client on every call.
+/// <see cref="OidcAuthService"/> caches its configuration managers in a static field.
+/// Holding one client there pins its handler past the factory's rotation window.
+/// </summary>
+internal sealed class FactoryDocumentRetriever(
+    IHttpClientFactory httpClientFactory,
+    bool requireHttps) : IDocumentRetriever
+{
+    public Task<string> GetDocumentAsync(string address, CancellationToken cancel) =>
+        new HttpDocumentRetriever(httpClientFactory.CreateClient(Constants.HttpClientOidcAuthName))
+            { RequireHttps = requireHttps }
+            .GetDocumentAsync(address, cancel);
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcFlowState.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcFlowState.cs
@@ -1,0 +1,11 @@
+namespace Cleanuparr.Infrastructure.Features.Auth.Models;
+
+internal sealed class OidcFlowState
+{
+    public required string State { get; init; }
+    public required string Nonce { get; init; }
+    public required string CodeVerifier { get; init; }
+    public required string RedirectUri { get; init; }
+    public string? InitiatorUserId { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcOneTimeCodeEntry.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcOneTimeCodeEntry.cs
@@ -1,0 +1,9 @@
+namespace Cleanuparr.Infrastructure.Features.Auth.Models;
+
+internal sealed class OidcOneTimeCodeEntry
+{
+    public required string AccessToken { get; init; }
+    public required string RefreshToken { get; init; }
+    public required int ExpiresIn { get; init; }
+    public required DateTimeOffset CreatedAt { get; init; }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcTokenResponse.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/Models/OidcTokenResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Cleanuparr.Infrastructure.Features.Auth.Models;
+
+internal sealed class OidcTokenResponse
+{
+    [JsonPropertyName("id_token")]
+    public string IdToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("token_type")]
+    public string TokenType { get; set; } = string.Empty;
+}

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Auth;
+using Cleanuparr.Shared.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Protocols;
@@ -41,7 +42,7 @@ public sealed class OidcAuthService : IOidcAuthService
         ILogger<OidcAuthService> logger)
     {
         _httpClientFactory = httpClientFactory;
-        _httpClient = httpClientFactory.CreateClient("OidcAuth");
+        _httpClient = httpClientFactory.CreateClient(Constants.HttpClientOidcAuthName);
         _usersContext = usersContext;
         _logger = logger;
     }
@@ -511,7 +512,7 @@ public sealed class OidcAuthService : IOidcAuthService
 
         public Task<string> GetDocumentAsync(string address, CancellationToken cancel)
         {
-            HttpClient client = _httpClientFactory.CreateClient("OidcAuth");
+            HttpClient client = _httpClientFactory.CreateClient(Constants.HttpClientOidcAuthName);
             HttpDocumentRetriever retriever = new(client) { RequireHttps = _requireHttps };
 
             return retriever.GetDocumentAsync(address, cancel);

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Cleanuparr.Infrastructure.Features.Auth.Models;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Auth;
 using Cleanuparr.Shared.Helpers;
@@ -492,60 +493,5 @@ public sealed class OidcAuthService : IOidcAuthService
     public static void ClearDiscoveryCache()
     {
         ConfigManagers.Clear();
-    }
-
-    /// <summary>
-    /// Fetches the discovery document with a fresh client on every call.
-    /// <see cref="ConfigManagers"/> is static.
-    /// Holding one client there pins its handler past the factory's rotation window.
-    /// </summary>
-    private sealed class FactoryDocumentRetriever : IDocumentRetriever
-    {
-        private readonly IHttpClientFactory _httpClientFactory;
-        private readonly bool _requireHttps;
-
-        public FactoryDocumentRetriever(IHttpClientFactory httpClientFactory, bool requireHttps)
-        {
-            _httpClientFactory = httpClientFactory;
-            _requireHttps = requireHttps;
-        }
-
-        public Task<string> GetDocumentAsync(string address, CancellationToken cancel)
-        {
-            HttpClient client = _httpClientFactory.CreateClient(Constants.HttpClientOidcAuthName);
-            HttpDocumentRetriever retriever = new(client) { RequireHttps = _requireHttps };
-
-            return retriever.GetDocumentAsync(address, cancel);
-        }
-    }
-
-    private sealed class OidcFlowState
-    {
-        public required string State { get; init; }
-        public required string Nonce { get; init; }
-        public required string CodeVerifier { get; init; }
-        public required string RedirectUri { get; init; }
-        public string? InitiatorUserId { get; init; }
-        public required DateTimeOffset CreatedAt { get; init; }
-    }
-
-    private sealed class OidcOneTimeCodeEntry
-    {
-        public required string AccessToken { get; init; }
-        public required string RefreshToken { get; init; }
-        public required int ExpiresIn { get; init; }
-        public required DateTimeOffset CreatedAt { get; init; }
-    }
-
-    private sealed class OidcTokenResponse
-    {
-        [System.Text.Json.Serialization.JsonPropertyName("id_token")]
-        public string IdToken { get; set; } = string.Empty;
-
-        [System.Text.Json.Serialization.JsonPropertyName("access_token")]
-        public string AccessToken { get; set; } = string.Empty;
-
-        [System.Text.Json.Serialization.JsonPropertyName("token_type")]
-        public string TokenType { get; set; } = string.Empty;
     }
 }

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/OidcAuthService.cs
@@ -30,6 +30,7 @@ public sealed class OidcAuthService : IOidcAuthService
     private static readonly Timer CleanupTimer = new(CleanupExpiredEntries, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
     #pragma warning restore IDE0052
 
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly HttpClient _httpClient;
     private readonly UsersContext _usersContext;
     private readonly ILogger<OidcAuthService> _logger;
@@ -39,6 +40,7 @@ public sealed class OidcAuthService : IOidcAuthService
         UsersContext usersContext,
         ILogger<OidcAuthService> logger)
     {
+        _httpClientFactory = httpClientFactory;
         _httpClient = httpClientFactory.CreateClient("OidcAuth");
         _usersContext = usersContext;
         _logger = logger;
@@ -277,7 +279,7 @@ public sealed class OidcAuthService : IOidcAuthService
             return new ConfigurationManager<OpenIdConnectConfiguration>(
                 metadataAddress,
                 new OpenIdConnectConfigurationRetriever(),
-                new HttpDocumentRetriever(_httpClient) { RequireHttps = !isLocalhost });
+                new FactoryDocumentRetriever(_httpClientFactory, requireHttps: !isLocalhost));
         });
 
         return await configManager.GetConfigurationAsync();
@@ -489,6 +491,31 @@ public sealed class OidcAuthService : IOidcAuthService
     public static void ClearDiscoveryCache()
     {
         ConfigManagers.Clear();
+    }
+
+    /// <summary>
+    /// Fetches the discovery document with a fresh client on every call.
+    /// <see cref="ConfigManagers"/> is static.
+    /// Holding one client there pins its handler past the factory's rotation window.
+    /// </summary>
+    private sealed class FactoryDocumentRetriever : IDocumentRetriever
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly bool _requireHttps;
+
+        public FactoryDocumentRetriever(IHttpClientFactory httpClientFactory, bool requireHttps)
+        {
+            _httpClientFactory = httpClientFactory;
+            _requireHttps = requireHttps;
+        }
+
+        public Task<string> GetDocumentAsync(string address, CancellationToken cancel)
+        {
+            HttpClient client = _httpClientFactory.CreateClient("OidcAuth");
+            HttpDocumentRetriever retriever = new(client) { RequireHttps = _requireHttps };
+
+            return retriever.GetDocumentAsync(address, cancel);
+        }
     }
 
     private sealed class OidcFlowState

--- a/code/backend/Cleanuparr.Infrastructure/Features/Auth/PlexAuthService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/Auth/PlexAuthService.cs
@@ -16,7 +16,7 @@ public sealed class PlexAuthService : IPlexAuthService
 
     public PlexAuthService(IHttpClientFactory httpClientFactory, ILogger<PlexAuthService> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("PlexAuth");
+        _httpClient = httpClientFactory.CreateClient(Constants.HttpClientPlexAuthName);
         _logger = logger;
         _clientIdentifier = GetOrCreateClientIdentifier();
     }

--- a/code/backend/Cleanuparr.Shared/Helpers/Constants.cs
+++ b/code/backend/Cleanuparr.Shared/Helpers/Constants.cs
@@ -10,6 +10,10 @@ public static class Constants
 
     public const string HttpClientWithRetryName = "retry";
 
+    public const string HttpClientPlexAuthName = "PlexAuth";
+
+    public const string HttpClientOidcAuthName = "OidcAuth";
+
     public static readonly MemoryCacheEntryOptions DefaultCacheEntryOptions = new()
     {
         SlidingExpiration = TimeSpan.FromMinutes(10)


### PR DESCRIPTION
The OIDC service was caching the HTTP client instead of create new ones when needed.